### PR TITLE
Library addressing improvements

### DIFF
--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/Extensions.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/Extensions.cs
@@ -32,5 +32,33 @@ namespace S7PLCSIM_Library
         {
             return Enum.GetName(typeof(EPrimitiveDataType), t) ?? "(Unknown Type)";
         }
+
+        public static byte ToBitSize(this EPrimitiveDataType t)
+        {
+            switch (t)
+            {
+                case EPrimitiveDataType.Bool:
+                    return 1;
+                case EPrimitiveDataType.Char:
+                case EPrimitiveDataType.Int8:
+                case EPrimitiveDataType.UInt8:
+                    return 8;
+                case EPrimitiveDataType.Int16:
+                case EPrimitiveDataType.UInt16:
+                case EPrimitiveDataType.WChar:
+                    return 16;
+                case EPrimitiveDataType.UInt32:
+                case EPrimitiveDataType.Int32:
+                case EPrimitiveDataType.Float:
+                    return 32;
+                case EPrimitiveDataType.Double:
+                case EPrimitiveDataType.Int64:
+                case EPrimitiveDataType.UInt64:
+                    return 64;
+                default:
+                    throw new ArgumentException(
+                        $"Invalid primitive data type for simulation address: {t.ToHumanString()} = {t}");
+            }
+        }
     }
 }

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/Extensions.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/Extensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Siemens.Simatic.Simulation.Runtime;
 
 namespace S7PLCSIM_Library
@@ -25,6 +26,11 @@ namespace S7PLCSIM_Library
                     $"Type = {value.Type}",
                 }
             );
+        }
+
+        public static string ToHumanString(this EPrimitiveDataType t)
+        {
+            return Enum.GetName(typeof(EPrimitiveDataType), t) ?? "(Unknown Type)";
         }
     }
 }

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddress.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddress.cs
@@ -66,7 +66,8 @@ namespace S7PLCSIM_Library
             var valueBitArray = new BitArray(BitConverter.GetBytes(value));
             for (int i = bitOffset, j = 0; i < bitOffset+bitSize; i++, j++)
                 inputBitArray.Set(i, valueBitArray[j]);
-            byte[] outputBytes = new byte[8];
+            // 8 bytes + 1 extra byte for bit offset. Eg. write Int64 to %I0.2 -> Reads 9 bytes from simulation
+            byte[] outputBytes = new byte[9];
             inputBitArray.CopyTo(outputBytes, 0);
             return outputBytes;
         }

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddress.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddress.cs
@@ -35,7 +35,7 @@ namespace S7PLCSIM_Library
 
         // If bit size is unspecified, use default bit size associated with dataType. eg UInt32 will have BitSize = 32
         public SimulationAddress(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) 
-            : this(name, byteOffset, bitOffset, DataTypeToBitSize(dataType), dataType, instance) { }
+            : this(name, byteOffset, bitOffset, dataType.ToBitSize(), dataType, instance) { }
 
         public SimulationAddress(string name, uint byteOffset, byte bitOffset, byte bitSize, EPrimitiveDataType dataType, IInstance instance)
         {
@@ -108,33 +108,6 @@ namespace S7PLCSIM_Library
             }
         }
         
-        private static byte DataTypeToBitSize(EPrimitiveDataType dataType)
-        {
-            switch (dataType)
-            {
-                case EPrimitiveDataType.Bool:
-                    return 1;
-                case EPrimitiveDataType.Char:
-                case EPrimitiveDataType.Int8:
-                case EPrimitiveDataType.UInt8:
-                    return 8;
-                case EPrimitiveDataType.Int16:
-                case EPrimitiveDataType.UInt16:
-                case EPrimitiveDataType.WChar:
-                    return 16;
-                case EPrimitiveDataType.UInt32:
-                case EPrimitiveDataType.Int32:
-                case EPrimitiveDataType.Float:
-                    return 32;
-                case EPrimitiveDataType.Double:
-                case EPrimitiveDataType.Int64:
-                case EPrimitiveDataType.UInt64:
-                    return 64;
-                default:
-                    throw new ArgumentException(
-                        $"Invalid primitive data type for simulation address: {dataType.ToHumanString()} = {dataType}");
-            }
-        }
         public override string ToString() => $"{ByteOffset}.{BitOffset}, Bits={BitSize}, Type={DataType.ToHumanString()} ({DataType})";
     }
 }

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddress.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddress.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using Siemens.Simatic.Simulation.Runtime;
 
 namespace S7PLCSIM_Library
@@ -11,9 +12,6 @@ namespace S7PLCSIM_Library
         /// Data type at address
         public EPrimitiveDataType DataType { get; }
 
-        /// String version of DataType - Helps with error messages
-        protected string DataTypeName { get; }
-
         /// Byte value in Q{Byte}.{Bit}
         public uint ByteOffset { get; }
 
@@ -21,20 +19,72 @@ namespace S7PLCSIM_Library
         public byte BitOffset { get; }
 
         /// Number of bits taken up by primitive type 'type'
-        public uint Size { get; }
+        public byte BitSize { get; }
         
         /// Bit offset where this address object begins in memory
-        public uint StartBit { get; }
-        
+        public uint StartBit => ByteOffset * 8 + BitOffset;
+
         /// Bit offset where this address object ends in memory
-        public uint EndBit { get; }
+        public uint EndBit => StartBit + BitSize - 1;
+        
+        /// Minimum number of bytes to read from simulation memory to retrieve full value
+        public uint ByteSize => ((StartBit + BitSize - 1) / 8) + 1;
 
         /// Human friendly name to reference to IO address
         public string Name { get; }
 
-        /// Current value of IO address
-        public SDataValue Value { get; protected set; }
+        // If bit size is unspecified, use default bit size associated with dataType. eg UInt32 will have BitSize = 32
+        public SimulationAddress(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) 
+            : this(name, byteOffset, bitOffset, DataTypeToBitSize(dataType), dataType, instance) { }
+
+        public SimulationAddress(string name, uint byteOffset, byte bitOffset, byte bitSize, EPrimitiveDataType dataType, IInstance instance)
+        {
+            Instance = instance;
+            Name = name;
+            ByteOffset = byteOffset;
+            BitOffset = bitOffset;
+            DataType = dataType;
+            BitSize = bitSize;
+            
+            if (bitOffset > 7)
+                throw new ArgumentException($"Invalid Bit Offset specified - Bit offset must be between 0-7. Given Bit Offset = {bitOffset}");
+            
+            if (bitSize > 64)
+                throw new ArgumentException($"Invalid Bit Size specified - Bit size must not exceed 64 bits. Given Bit Size = {bitSize}");
+
+            if (dataType == EPrimitiveDataType.Unspecific || dataType == EPrimitiveDataType.Struct)
+                throw new ArgumentException($"Invalid Data Type - The following data types are unsupported: {EPrimitiveDataType.Unspecific.ToHumanString()}, {EPrimitiveDataType.Struct.ToHumanString()}");
+        }
         
+        
+        /// <summary>
+        /// Write the bits of `value` overtop bits of `input` starting at `bitOffset` until `bitSize`
+        /// </summary>
+        protected static byte[] ShiftWrite(byte[] inputBytes, ulong value, byte bitOffset, byte bitSize)
+        {
+            var inputBitArray = new BitArray(inputBytes);
+            var valueBitArray = new BitArray(BitConverter.GetBytes(value));
+            for (int i = bitOffset, j = 0; i < bitOffset+bitSize; i++, j++)
+                inputBitArray.Set(i, valueBitArray[j]);
+            byte[] outputBytes = new byte[8];
+            inputBitArray.CopyTo(outputBytes, 0);
+            return outputBytes;
+        }
+
+        /// <summary>
+        /// Extract a ulong value from input array, interpreting the value from binary as starting at `bitCount` and ranging until `bitOffset`
+        /// </summary>
+        protected static ulong ShiftRead(byte[] inputBytes, byte bitOffset, byte bitSize)
+        {
+            var inputBitArray = new BitArray(inputBytes);
+            var outputBitArray = new BitArray(bitSize);
+            for (int i=bitOffset, j = 0; i < bitOffset + bitSize; i++, j++)
+                outputBitArray.Set(j, inputBitArray[i]);
+            byte[] outputBytes = new byte[8];
+            outputBitArray.CopyTo(outputBytes, 0);
+            return BitConverter.ToUInt64(outputBytes);
+        }
+
         protected byte[] ValueToBytes(SDataValue value)
         {
             switch (DataType)
@@ -54,114 +104,37 @@ namespace S7PLCSIM_Library
                 case EPrimitiveDataType.WChar: return BitConverter.GetBytes(value.WChar);
                 default:
                     throw new ArgumentException(
-                        $"Cannot convert data type to byte array: {DataTypeName} = {DataType}");
+                        $"Cannot convert data type to byte array: {DataType.ToHumanString()} = {DataType}");
             }
         }
-
-        protected SDataValue BytesToValue(byte[] bytes)
+        
+        private static byte DataTypeToBitSize(EPrimitiveDataType dataType)
         {
-            SDataValue value = new SDataValue();
-
-            // TODO: Confirm `BitConverter` does the right thing WRT endianness compared to the simulator
-            switch (DataType)
-            {
-                case EPrimitiveDataType.Bool:
-                    value.Bool = BitConverter.ToBoolean(bytes);
-                    break;
-                case EPrimitiveDataType.Char:
-                    value.Char = (sbyte) bytes[0];
-                    break;
-                case EPrimitiveDataType.Double:
-                    value.Double = BitConverter.ToDouble(bytes);
-                    break;
-                case EPrimitiveDataType.Float:
-                    value.Float = BitConverter.ToSingle(bytes);
-                    break;
-                case EPrimitiveDataType.Int8:
-                    value.Int8 = (sbyte) bytes[0];
-                    break;
-                case EPrimitiveDataType.Int16:
-                    value.Int16 = BitConverter.ToInt16(bytes);
-                    break;
-                case EPrimitiveDataType.Int32:
-                    value.Int32 = BitConverter.ToInt32(bytes);
-                    break;
-                case EPrimitiveDataType.Int64:
-                    value.Int64 = BitConverter.ToInt64(bytes);
-                    break;
-                case EPrimitiveDataType.UInt8:
-                    value.UInt8 = bytes[0];
-                    break;
-                case EPrimitiveDataType.UInt16:
-                    value.UInt16 = BitConverter.ToUInt16(bytes);
-                    break;
-                case EPrimitiveDataType.UInt32:
-                    value.UInt32 = BitConverter.ToUInt32(bytes);
-                    break;
-                case EPrimitiveDataType.UInt64:
-                    value.UInt64 = BitConverter.ToUInt64(bytes);
-                    break;
-                case EPrimitiveDataType.WChar:
-                    value.WChar = BitConverter.ToChar(bytes);
-                    break;
-                default:
-                    throw new ArgumentException(
-                        $"Cannot convert byte array to desired Type: {DataTypeName} = {DataType}, Bytes = {{{string.Join(",", bytes)}}}");
-            }
-
-            return value;
-        }
-
-        // Note: Types 'EPrimitiveDataType.Struct' and 'EPrimitiveDataType.Unspecific' not supported
-        public SimulationAddress(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance)
-        {
-            Instance = instance;
-            Name = name;
-            ByteOffset = byteOffset;
-            BitOffset = bitOffset;
-            DataType = dataType;
-            DataTypeName = Enum.GetName(typeof(EPrimitiveDataType), dataType);
-
             switch (dataType)
             {
                 case EPrimitiveDataType.Bool:
-                    Size = 1;
-                    break;
+                    return 1;
                 case EPrimitiveDataType.Char:
                 case EPrimitiveDataType.Int8:
                 case EPrimitiveDataType.UInt8:
-                    Size = 8;
-                    break;
+                    return 8;
                 case EPrimitiveDataType.Int16:
                 case EPrimitiveDataType.UInt16:
                 case EPrimitiveDataType.WChar:
-                    Size = 16;
-                    break;
+                    return 16;
                 case EPrimitiveDataType.UInt32:
                 case EPrimitiveDataType.Int32:
                 case EPrimitiveDataType.Float:
-                    Size = 32;
-                    break;
+                    return 32;
                 case EPrimitiveDataType.Double:
                 case EPrimitiveDataType.Int64:
                 case EPrimitiveDataType.UInt64:
-                    Size = 64;
-                    break;
+                    return 64;
                 default:
                     throw new ArgumentException(
-                        $"Invalid primitive data type for simulation address: {DataTypeName} = {DataType}");
-            }
-
-            StartBit = byteOffset * 8 + bitOffset;
-            EndBit = StartBit + Size;
-            
-            // TODO: Throw an exception bitOffset > 0 when dataType != EPrimitiveDataType.Bool
-            if (dataType != EPrimitiveDataType.Bool && bitOffset > 0)
-            {
-                throw new ArgumentException(
-                    @$"Using non-zero bit offset for data types other than ""Bool"" is unsupported. Data-Type = {DataTypeName} = {DataType}, Bit-Offset = {BitOffset}");
+                        $"Invalid primitive data type for simulation address: {dataType.ToHumanString()} = {dataType}");
             }
         }
-        public override string ToString() => $"{ByteOffset}.{BitOffset}, Bits={Size}, Type={DataTypeName} ({DataType})";
+        public override string ToString() => $"{ByteOffset}.{BitOffset}, Bits={BitSize}, Type={DataType.ToHumanString()} ({DataType})";
     }
 }

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddressContainer.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationAddressContainer.cs
@@ -40,8 +40,17 @@ namespace S7PLCSIM_Library
             
             foreach (var existing in _addresses.Values)
             {
-                if (address.StartBit >= existing.StartBit &&
-                    address.StartBit < existing.EndBit)
+                // Address start bit lies between existing address
+                bool startBitBetween =
+                    (address.StartBit >= existing.StartBit) &&
+                    (address.StartBit <= existing.EndBit);
+
+                // Address end bit lies between existing address
+                bool endBitBetween =
+                    (address.EndBit >= existing.StartBit) &&
+                    (address.EndBit <= existing.EndBit);
+
+                if (startBitBetween || endBitBetween)
                 {
                     overlapper = existing;
                     return true;

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationInput.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationInput.cs
@@ -6,8 +6,8 @@ namespace S7PLCSIM_Library
 {
     public class SimulationInput : SimulationAddress
     {
-        public SimulationInput(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) 
-            : base(name, byteOffset, bitOffset, dataType, instance) { }
+        public SimulationInput(string name, uint byteOffset, byte bitOffset, byte bitSize, EPrimitiveDataType dataType, IInstance instance) 
+            : base(name, byteOffset, bitOffset, bitSize, dataType, instance) { }
 
         private SDataValue _value;
         public SDataValue Value => _value;

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationInput.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationInput.cs
@@ -1,30 +1,25 @@
 using System;
+using System.Text;
 using Siemens.Simatic.Simulation.Runtime;
 
 namespace S7PLCSIM_Library
 {
     public class SimulationInput : SimulationAddress
     {
-        public SimulationInput(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) : base(name, byteOffset, bitOffset, dataType, instance)
-        {
-        }
+        public SimulationInput(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) 
+            : base(name, byteOffset, bitOffset, dataType, instance) { }
+
+        private SDataValue _value;
+        public SDataValue Value => _value;
 
         public void Write(SDataValue value)
         {
-            // Record last written value
-            Value = value;
-            
-            byte[] bytes = ValueToBytes(value);
-            // Only write a single bit
-            if (DataType == EPrimitiveDataType.Bool)
-            {
-                Instance.InputArea.WriteBit(ByteOffset, BitOffset, bytes[0] > 0);
-            }
-            else // Otherwise write the whole byte area
-            {
-                Instance.InputArea.WriteBytes(ByteOffset, bytes);
-            }
+            byte[] input = Instance.InputArea.ReadBytes(ByteOffset, ByteSize);
+            byte[] output = ShiftWrite(input, value.UInt64, BitOffset, BitSize);
+            Instance.InputArea.WriteBytes(ByteOffset, output);
+            _value = value; // Set last written value
         }
+        
         public override string ToString() => $"%I{base.ToString()}";
     }
 }

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationOutput.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationOutput.cs
@@ -5,8 +5,8 @@ namespace S7PLCSIM_Library
 {
     public class SimulationOutput : SimulationAddress
     {
-        public SimulationOutput(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) 
-            : base(name, byteOffset, bitOffset, dataType, instance) { }
+        public SimulationOutput(string name, uint byteOffset, byte bitOffset, byte bitSize, EPrimitiveDataType dataType, IInstance instance) 
+            : base(name, byteOffset, bitOffset, bitSize, dataType, instance) { }
 
         private SDataValue _value;
         public SDataValue Value => _value;

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationOutput.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationOutput.cs
@@ -5,25 +5,17 @@ namespace S7PLCSIM_Library
 {
     public class SimulationOutput : SimulationAddress
     {
-        public SimulationOutput(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) : base(name, byteOffset, bitOffset, dataType, instance)
-        {
-        }
-    
+        public SimulationOutput(string name, uint byteOffset, byte bitOffset, EPrimitiveDataType dataType, IInstance instance) 
+            : base(name, byteOffset, bitOffset, dataType, instance) { }
+
+        private SDataValue _value;
+        public SDataValue Value => _value;
+
         public SDataValue Read()
         {
-            SDataValue value = new SDataValue();
-            if (DataType == EPrimitiveDataType.Bool)
-            {
-                value.Bool = Instance.OutputArea.ReadBit(ByteOffset, BitOffset);
-            }
-            else
-            {
-                byte[] bytes = Instance.OutputArea.ReadBytes(ByteOffset, BitOffset);
-                value = BytesToValue(bytes);
-            }
-            // Record last-read value and return it
-            Value = value;
-            return value;
+            byte[] bytes = Instance.OutputArea.ReadBytes(ByteOffset, ByteSize);
+            _value.UInt64 = ShiftRead(bytes, BitOffset, BitSize);
+            return _value;
         }
         
         public override string ToString() => $"%Q{base.ToString()}";

--- a/src/S7PLCSIM-Tool/S7PLCSIM-Tool/Program.cs
+++ b/src/S7PLCSIM-Tool/S7PLCSIM-Tool/Program.cs
@@ -235,7 +235,7 @@ namespace S7PLCSIM_Tool
         {
             // TODO: How do we set appropriate SDataValue fields based on address value type?
             // Should we have a generic extension method somewhere?
-            client.IAddress[name].Write(new SDataValue() { UInt8 = byte.Parse(value)});
+            client.IAddress[name].Write(new SDataValue() { UInt64 = ulong.Parse(value)});
         }
 
         private static void CommandCreate(SimulationClient client, string name, string location, string type)


### PR DESCRIPTION
```
Changelog

SimulationAddress.cs:
    - (!) Support reading/writing address values of any size under 64 bits at any offset
    - Prefer getter/autoproperties for computable fields
    - Make 'Value' a property of subclasses rather than SimulationAddress
    - Cleanup properties and remove unused code

Extensions.cs:
    - Add EPrimitiveDataType.ToHumanString() extension
    - Add EPrimitiveDataType.ToBitSize() extension

SimulationAddressContainer:
    - Fix Overlaps() so both start/end address points are considered

SimulationInput.cs / SimulationOutput.cs:
    - Cleanup Read and Write, use new Shift* methods
    - Update Add() methods to allow specifying custom bit size
```