### PR TITLE
Avoid calling reset twice when returning to main menu

### DIFF
--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/GameScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/GameScreen.cs
@@ -89,7 +89,7 @@ namespace MarbleSorterGame.Screens
             _window.MouseButtonPressed += GameMouseClickEventHandler;
             _window.KeyPressed += GameKeyEventHandler;
             _window.MouseMoved += GameMouseMoveEventHandler;
-
+            
             // Color of the menu and legend background
             var chromeColor = new SFML.Graphics.Color(218, 224, 226);
 
@@ -529,14 +529,10 @@ namespace MarbleSorterGame.Screens
         public override void Draw(RenderWindow window)
         {
             foreach (var drawable in _drawables)
-            {
                 window.Draw(drawable);
-            }
             
             foreach (var entity in _entities) 
-            {
                 entity.Render(window);
-            }
         }
 
         private void PauseButtonClickHandler(object? sender, MouseButtonEventArgs args)
@@ -559,7 +555,6 @@ namespace MarbleSorterGame.Screens
         private void MainMenuButtonClickHandler(object? sender, MouseButtonEventArgs args)
         {
             Dispose();
-            Reset();
             MarbleSorterGame.ActiveMenu = Menu.Main;
         }
 


### PR DESCRIPTION
Before this patch we would call `Reset()` twice: Once when leaving the game screen and once when returning. This would setup keyboard event handlers twice, causing any keyboard inputs to be immediately duplicated in the driver.

Closes #73 