### PR TITLE
Implement configurable update interval

### DIFF
--- a/src/MarbleSorterGame/MarbleSorterGame/AssetBundleLoader.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/AssetBundleLoader.cs
@@ -25,16 +25,17 @@ namespace MarbleSorterGame
         public List<IoMapConfiguration> IoMapConfiguration { get; set; }
         public Font Font { get; set; }
         public string Error { get;  }
+        public string AbsoluteAssetDirectoryPath { get; }
         
         public AssetBundleLoader(String assetDirectoryRelativePath)
         {
-            string assetDirectoryAbsolutePath = Path.Join(Directory.GetCurrentDirectory(), assetDirectoryRelativePath);
+            AbsoluteAssetDirectoryPath = Path.Join(Directory.GetCurrentDirectory(), assetDirectoryRelativePath);
             string configFile = "";
             try
             {
                 // Load + Validate Game Configuration
                 // TODO: Validate IOMap configuration
-                string GetConfig(string file) => Path.Join(assetDirectoryAbsolutePath, "Config", file);
+                string GetConfig(string file) => Path.Join(AbsoluteAssetDirectoryPath, "Config", file);
                 configFile = "game.json";
                 GameConfiguration = ConfigurationLoader.LoadGameConfiguration(GetConfig(configFile));
                 GameConfiguration.Validate(); // May throw MarbleGameConfigException
@@ -42,15 +43,15 @@ namespace MarbleSorterGame
                 IoMapConfiguration = ConfigurationLoader.LoadIoMapConfiguration(GetConfig(configFile)); 
 
                 // Load Fonts
-                Font = new Font(Path.Join(assetDirectoryAbsolutePath, "Fonts", "DejaVuSansMono.ttf"));
+                Font = new Font(Path.Join(AbsoluteAssetDirectoryPath, "Fonts", "DejaVuSansMono.ttf"));
 
                 // Load Sounds
-                string GetSound(string file) => Path.Join(assetDirectoryAbsolutePath, "Sounds", file);
+                string GetSound(string file) => Path.Join(AbsoluteAssetDirectoryPath, "Sounds", file);
                 BucketDropSuccess = new Sound(new SoundBuffer(GetSound("bucketDropSuccess.ogg")));
                 BucketDropFail = new Sound(new SoundBuffer(GetSound("bucketDropFail.ogg")));
 
                 // Load Images
-                string GetImage(string file) => Path.Join(assetDirectoryAbsolutePath, "Images", file);
+                string GetImage(string file) => Path.Join(AbsoluteAssetDirectoryPath, "Images", file);
                 BucketTexture = new Texture(GetImage("bucket3.png"));
                 SensorTexture = new Texture(GetImage("sensor.png"));
                 MarbleRedTexture = new Texture(GetImage("marbleRed.png"));
@@ -63,7 +64,7 @@ namespace MarbleSorterGame
                 var lines = new Dictionary<string, string>();
                 lines["Exception"] = e.GetType().FullName;
                 lines["Message"] = e.Message;
-                lines["Asset Path"] = assetDirectoryAbsolutePath;
+                lines["Asset Path"] = AbsoluteAssetDirectoryPath;
                 Error = FormatErrorString("Failed to load game resources", lines);
             }
             catch (JsonException e)
@@ -73,7 +74,7 @@ namespace MarbleSorterGame
                 lines["Exception"] = e.GetType().FullName;
                 lines["LineNumber"] = e.LineNumber.ToString();
                 lines["Message"] = e.Message;
-                lines["File"] = Path.Join(assetDirectoryAbsolutePath, configFile);
+                lines["File"] = Path.Join(AbsoluteAssetDirectoryPath, configFile);
                 Error = FormatErrorString($"Error loading '{configFile}'", lines);
             }
             catch (ConfigValidationException e)
@@ -82,7 +83,7 @@ namespace MarbleSorterGame
                 var lines = new Dictionary<string, string>();
                 lines["Exception"] = e.GetType().FullName;
                 lines["Message"] = e.Message;
-                lines["File"] = Path.Join(assetDirectoryAbsolutePath, configFile);
+                lines["File"] = Path.Join(AbsoluteAssetDirectoryPath, configFile);
                 Error = FormatErrorString($"Validation error found in '{configFile}'", lines);
             }
         }

--- a/src/MarbleSorterGame/MarbleSorterGame/AssetBundleLoader.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/AssetBundleLoader.cs
@@ -10,9 +10,7 @@ using MarbleSorterGame.Utilities;
 
 namespace MarbleSorterGame
 {
-    /// <summary>
-    /// Organizes and stores paths to required assets
-    /// </summary>
+    // Organizes and stores paths to required assets
     public class AssetBundleLoader : IAssetBundle
     {
         public Sound BucketDrop { get; set; }

--- a/src/MarbleSorterGame/MarbleSorterGame/Assets/Config/game.json
+++ b/src/MarbleSorterGame/MarbleSorterGame/Assets/Config/game.json
@@ -1,6 +1,6 @@
 {
-  "ScreenWidth": 1280,
-  "ScreenHeight": 720,
+  "ScreenWidth": 1920,
+  "ScreenHeight": 1080,
   "MarblePeriod": 9.0,
   "GatePeriod": 0.5,
   "TrapDoorPeriod": 0.5,

--- a/src/MarbleSorterGame/MarbleSorterGame/Assets/Config/game.json
+++ b/src/MarbleSorterGame/MarbleSorterGame/Assets/Config/game.json
@@ -1,6 +1,6 @@
 {
-  "ScreenWidth": 1920,
-  "ScreenHeight": 1080,
+  "ScreenWidth": 1280,
+  "ScreenHeight": 720,
   "MarblePeriod": 9.0,
   "GatePeriod": 0.5,
   "TrapDoorPeriod": 0.5,

--- a/src/MarbleSorterGame/MarbleSorterGame/Assets/Config/game.json
+++ b/src/MarbleSorterGame/MarbleSorterGame/Assets/Config/game.json
@@ -5,7 +5,10 @@
   "GatePeriod": 0.5,
   "TrapDoorPeriod": 0.5,
   "Driver": "Keyboard",
-  "DriverOptions": { "SimulationName":  "test" },
+  "DriverOptions": { 
+    "SimulationName":  "test",
+    "UpdateInterval": 5
+  },
   "Preset": {
     "Marbles": [
       { "Color": "Random", "Weight": "Random" },

--- a/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
@@ -85,6 +85,7 @@ namespace MarbleSorterGame
     public class SimulationDriverOptions
     {
         public string SimulationName { get; set; }
+        public uint UpdateInterval { get; set; }
         public override string ToString() => $"SimulationDriverOptions: SimulationName = {SimulationName}";
     }
     

--- a/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
@@ -88,7 +88,7 @@ namespace MarbleSorterGame
         public override string ToString() => $"SimulationDriverOptions: SimulationName = {SimulationName}";
     }
     
-    /// Stores marble types from config file
+    // Stores marble types from config file
     public class MarbleConfig
     {
         public ConfigColor Color { get; set; }
@@ -97,7 +97,7 @@ namespace MarbleSorterGame
         public override string ToString() => $"MarbleConfig: Color = {Color}, Weight = {Weight}";
     }
 
-    /// Stores bucket requirements from config file
+    // Stores bucket requirements from config file
     public class BucketConfig
     {
         public int Capacity { get; set; }
@@ -107,7 +107,7 @@ namespace MarbleSorterGame
         public override string ToString() => $"BucketConfig: Capacity = {Capacity}, Color = {Color}, Weight = {Weight}";
     }
 
-    /// Stores values from config file
+    // Stores values from config file
     public class MarbleGameConfiguration
     {
         public MarbleGamePreset Preset { get; set; }

--- a/src/MarbleSorterGame/MarbleSorterGame/Drivers/KeyboardIODriver.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Drivers/KeyboardIODriver.cs
@@ -2,10 +2,8 @@ using SFML.Window;
 
 namespace MarbleSorterGame
 {
-    /// <summary>
-    /// Driver for communicating with the game through a keyboard.
-    /// Full game will use the S7IO Driver class, this driver is for early debug purposes.
-    /// </summary>
+    // Driver for communicating with the game through a keyboard.
+    // Full game will use the S7IO Driver class, this driver is for early debug purposes.
     public class KeyboardIODriver : IIODriver
     {
         public bool TrapDoor1 { get; set;  }
@@ -23,12 +21,12 @@ namespace MarbleSorterGame
         public byte PressureSensor { get; set; }
         public byte ColorSensor { get; set; }
 
-        /// This implementation does not update programatically, it uses keyboard input. See: UpdateByKey()
+        // This implementation does not update programatically, it uses keyboard input. See: UpdateByKey()
         public void Update()
         {
         }
 
-        /// Associates and Updates keyboard inputs to game inputs
+        // Associates and Updates keyboard inputs to game inputs
         public void UpdateByKey(KeyEventArgs key)
         {
             // Outputs: TrapDoor1, TrapDoor2, TrapDoor3, Gate, Conveyer
@@ -48,7 +46,7 @@ namespace MarbleSorterGame
                 TrapDoor3 = !TrapDoor3;
         }
         
-        /// Shows overall game state
+        // Shows overall game state
         public override string ToString()
         {
             return string.Join("\n", new string[]

--- a/src/MarbleSorterGame/MarbleSorterGame/Drivers/S7IODriver.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Drivers/S7IODriver.cs
@@ -145,10 +145,15 @@ namespace MarbleSorterGame
             set => _colorSensor.UInt8 = value;
         }
 
+        private ulong _updateCount;
+        private readonly uint _updateInterval;
+
         // Defines the addresses for the S7IO PLC Driver
         public S7IODriver(SimulationDriverOptions options, IList<IoMapConfiguration> iomaps)
         {
             _client = new SimulationClient(options.SimulationName);
+            _updateCount = 0;
+            _updateInterval = Math.Max(1, options.UpdateInterval);
 
             foreach (var map in iomaps)
             {
@@ -173,23 +178,27 @@ namespace MarbleSorterGame
         // Updates driver values by writing/reading from the game state
         public void Update()
         {
-            // Write simulation outputs
-            _client.IAddress[IKeys.TrapDoor1Open].Write(_trapDoor1Open);
-            _client.IAddress[IKeys.TrapDoor2Open].Write(_trapDoor2);
-            _client.IAddress[IKeys.TrapDoor3Open].Write(_trapDoor3);
-            _client.IAddress[IKeys.BucketMotionSensor].Write(_bucketMotionSensor);
-            _client.IAddress[IKeys.GateOpen].Write(_gateOpen);
-            _client.IAddress[IKeys.GateClosed].Write(_gateClosed);
-            _client.IAddress[IKeys.ConveyorMotionSensor].Write(_conveyorMotionSensor);
-            _client.IAddress[IKeys.WeightSensor].Write(_weightSensor);
-            _client.IAddress[IKeys.ColorSensor].Write(_colorSensor);
+            if (_updateCount % _updateInterval == 0)
+            {
+                // Write simulation outputs
+                _client.IAddress[IKeys.TrapDoor1Open].Write(_trapDoor1Open);
+                _client.IAddress[IKeys.TrapDoor2Open].Write(_trapDoor2);
+                _client.IAddress[IKeys.TrapDoor3Open].Write(_trapDoor3);
+                _client.IAddress[IKeys.BucketMotionSensor].Write(_bucketMotionSensor);
+                _client.IAddress[IKeys.GateOpen].Write(_gateOpen);
+                _client.IAddress[IKeys.GateClosed].Write(_gateClosed);
+                _client.IAddress[IKeys.ConveyorMotionSensor].Write(_conveyorMotionSensor);
+                _client.IAddress[IKeys.WeightSensor].Write(_weightSensor);
+                _client.IAddress[IKeys.ColorSensor].Write(_colorSensor);
 
-            // Read simulation inputs
-            _trapDoor1 = _client.QAddress[QKeys.TrapDoor1].Read();
-            _trapDoor2 = _client.QAddress[QKeys.TrapDoor2].Read();
-            _trapDoor3 = _client.QAddress[QKeys.TrapDoor3].Read();
-            _gate = _client.QAddress[QKeys.Gate].Read();
-            _conveyor = _client.QAddress[QKeys.Conveyor].Read();
+                // Read simulation inputs
+                _trapDoor1 = _client.QAddress[QKeys.TrapDoor1].Read();
+                _trapDoor2 = _client.QAddress[QKeys.TrapDoor2].Read();
+                _trapDoor3 = _client.QAddress[QKeys.TrapDoor3].Read();
+                _gate = _client.QAddress[QKeys.Gate].Read();
+                _conveyor = _client.QAddress[QKeys.Conveyor].Read();
+            }
+            _updateCount++;
         }
     }
 }

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Bucket.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Bucket.cs
@@ -7,9 +7,7 @@ using Color = MarbleSorterGame.Enums.Color;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Container for marbles to drop onto, contains requirements that must be fulfilled to complete the marble sorter game
-    /// </summary>
+    // Container for marbles to drop onto, contains requirements that must be fulfilled to complete the marble sorter game
     public class Bucket : GameEntity
     {
         private Sprite _bucket;
@@ -69,11 +67,7 @@ namespace MarbleSorterGame.GameEntities
             }
         }
 
-        /// <summary>
-        /// Insert marble into the bucket, return true/false depening on whether marble meets its requirements
-        /// </summary>
-        /// <param name="m">Marble to be inserted into</param>
-        /// <returns>Whether marble that was inserted was correctly dropped</returns>
+        // Insert marble into the bucket, return true/false depening on whether marble meets its requirements
         public bool InsertMarble(Marble m)
         {
             bool marbleOk = ValidateMarble(m);
@@ -93,11 +87,7 @@ namespace MarbleSorterGame.GameEntities
             return marbleOk;
         }
 
-        /// <summary>
-        /// Checks if marble that was dropped met the requirements
-        /// </summary>
-        /// <param name="m">Marble to be validated</param>
-        /// <returns>If marble was valid</returns>
+        // Checks if marble that was dropped met the requirements
         public bool ValidateMarble(Marble m)
         {
             return (_requiredColor == null || m.Color == _requiredColor)  &&
@@ -105,10 +95,7 @@ namespace MarbleSorterGame.GameEntities
                     TotalMarbles < Capacity;
         }
 
-        /// <summary>
-        /// Draws the bucket onto render target RenderWindow
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
+        // Draws the bucket onto render target RenderWindow
         public override void Render(RenderWindow window)
         {
            // base.Render(window);
@@ -121,10 +108,7 @@ namespace MarbleSorterGame.GameEntities
             window.Draw(_capacityLabel);
         }
         
-        /// <summary>
-        /// Extracts bucket assets, such as texture and sound, from bundle
-        /// </summary>
-        /// <param name="bundle">reference to bundle object containing asset references</param>
+        // Extracts bucket assets, such as texture and sound, from bundle
         public override void Load(IAssetBundle bundle)
         {
             _capacityLabel = new Text($"0/{Capacity}", bundle.Font);

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Button.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Button.cs
@@ -9,9 +9,7 @@ using Color = SFML.Graphics.Color;
 namespace MarbleSorterGame.GameEntities
 {
 
-	/// <summary>
-	/// Menu object that, when clicked, links to other screens or features
-	/// </summary>
+	// Menu object that, when clicked, links to other screens or features
 	public class Button : GameEntity
 	{
 		private RectangleShape _button;
@@ -43,14 +41,7 @@ namespace MarbleSorterGame.GameEntities
 			set => _text.DisplayedString = value;
 		}
 		
-		/// <summary>
-		/// Constructor of button
-		/// </summary>
-		/// <param name="displayText">Text the button will display</param>
-		/// <param name="fontScale">Text size of button</param>
-		/// <param name="font">Font of button</param>
-		/// <param name="position">Global vector position</param>
-		/// <param name="size">Global vector size</param>
+		// Constructor of button
 		public Button(string displayText, float fontScale, Font font, Vector2f position, Vector2f size) :
 			base(position, size)
 		{
@@ -81,12 +72,7 @@ namespace MarbleSorterGame.GameEntities
 			}
 		}
 
-		/// <summary>
-		/// checks whether button has been pressed with mouse coordinates
-		/// </summary>
-		/// <param name="x">Global x-coordinate of mouse position</param>
-		/// <param name="y">Global y-coordinate of mouse position</param>
-		/// <returns></returns>
+		// checks whether button has been pressed with mouse coordinates
 		public bool MouseInButton(int x, int y)
 		{
 			FloatRect buttonBounds = _button.GetGlobalBounds();
@@ -101,10 +87,7 @@ namespace MarbleSorterGame.GameEntities
 				 ClickEvent?.Invoke(sender, args);	
 		}
 
-		/// <summary>
-		/// Draws button
-		/// </summary>
-		/// <param name="window"></param>
+		// Draws button
 		public override void Render(RenderWindow window)
 		{
 			if (Disabled)
@@ -127,10 +110,7 @@ namespace MarbleSorterGame.GameEntities
 			window.Draw(_text);
 		}
 
-		/// <summary>
-		/// Loads assets required for button
-		/// </summary>
-        /// <param name="bundle">reference to bundle object containing asset references</param>
+		// Loads assets required for button
 		public override void Load(IAssetBundle bundle)
 		{
 		}

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/ColorSensor.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/ColorSensor.cs
@@ -4,9 +4,7 @@ using System;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Sensor that detects color of marble rolling past it
-    /// </summary>
+    // Sensor that detects color of marble rolling past it
     public class ColorSensor : Sensor
     {
         Color Value;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Conveyor.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Conveyor.cs
@@ -4,20 +4,13 @@ using System;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Moves marble towards the exit, contains trapdoors that drop the marbles
-    /// </summary>
+    // Moves marble towards the exit, contains trapdoors that drop the marbles
     public class Conveyor : GameEntity
     {
         private RectangleShape _conveyor;
         private Vector2f _conveyorSpeed;
 
-        /// <summary>
-        /// Constructor for conveyer
-        /// </summary>
-        /// <param name="position"></param>
-        /// <param name="size"></param>
-        /// <param name="conveyorSpeed"></param>
+        // Constructor for conveyer
         public Conveyor(Vector2f position, Vector2f size, Vector2f conveyorSpeed) : base(position, size)
         {
             _conveyor = Box;
@@ -29,18 +22,12 @@ namespace MarbleSorterGame.GameEntities
             _conveyor.Position = position;
         }
 
-        /// <summary>
-        /// Loads assets for conveyer
-        /// </summary>
-        /// <param name="bundle">reference to bundle object containing asset references</param>
+        // Loads assets for conveyer
         public override void Load(IAssetBundle bundle)
         {
         }
 
-        /// <summary>
-        /// Draws conveyer onto window
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
+        // Draws conveyer onto window
         public override void Render(RenderWindow window)
         {
             window.Draw(_conveyor);

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/GameEntity.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/GameEntity.cs
@@ -5,9 +5,7 @@ using MarbleSorterGame.GameEntities;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Describes every entity within the game that can be rendered/updated
-    /// </summary>
+    // Describes every entity within the game that can be rendered/updated
     public abstract class GameEntity
     {
         private RectangleShape _rect;
@@ -15,17 +13,17 @@ namespace MarbleSorterGame.GameEntities
         public String InfoText;
         public string Name { get; set; }
         
-        /// Bounding box of the game entity
+        // Bounding box of the game entity
         public RectangleShape Box => _rect;
         
-        /// Position of the game entity
+        // Position of the game entity
         public virtual Vector2f Position
         {
             get => _rect.Position;
             set => _rect.Position = value;
         }
 
-        /// Size of the game entity
+        // Size of the game entity
         public virtual Vector2f Size
         {
             get => _rect.Size;
@@ -38,11 +36,7 @@ namespace MarbleSorterGame.GameEntities
         {
         }
 
-        /// <summary>
-        /// Constructor for game entity
-        /// </summary>
-        /// <param name="position">Global vector coordinates of position</param>
-        /// <param name="size">Global vector describing size</param>
+        // Constructor for game entity
         public GameEntity(Vector2f position, Vector2f size)
         {
             _rect = new RectangleShape
@@ -55,23 +49,14 @@ namespace MarbleSorterGame.GameEntities
             };
         }
 
-        /// <summary>
-        /// Return a new scale value appropriate for fitting "sprite" inside of box "size"
-        /// </summary>
-        /// <param name="size">Vector size of entity bounds</param>
-        /// <param name="sprite">Entity sprite</param>
-        /// <returns></returns>
+        // Return a new scale value appropriate for fitting "sprite" inside of box "size"
         protected static Vector2f RescaleSprite(Vector2f size, Sprite sprite)
         {
             // Actual size of a sprite is: sprite.Scale * sprite.Texture.Size. To set the size of the sprite, we need to adjust the scale
             return new Vector2f(size.X / sprite.Texture.Size.X, size.Y / sprite.Texture.Size.Y);
         }
 
-        /// <summary>
-        /// Changes the default transformation origin from top left of entity object to its center
-        /// </summary>
-        /// <param name="texture">Game entity texture</param>
-        /// <returns>vector pointing to center of entity in global coordinates</returns>
+        // Changes the default transformation origin from top left of entity object to its center
         public Vector2f CenterOrigin(Texture texture)
         {
             FloatRect bounds = this.GlobalBounds;
@@ -82,11 +67,7 @@ namespace MarbleSorterGame.GameEntities
             );
         }
 
-        /// <summary>
-        /// Scales the game entity texture so that it fits its dimensions
-        /// </summary>
-        /// <param name="texture">Game entity texture</param>
-        /// <returns>New dimension vector correctly ratio'd for the game entity dimension</returns>
+        // Scales the game entity texture so that it fits its dimensions
         public Vector2f ScaleEntity(Texture texture)
         {
             Vector2u textureSize = texture.Size;
@@ -94,21 +75,13 @@ namespace MarbleSorterGame.GameEntities
             return scaleRatio;
         }
 
-        /// <summary>
-        /// Checks to see if game entity overlaps bounding box of current game entity
-        /// </summary>
-        /// <param name="entity">game entity to check overlap</param>
-        /// <returns></returns>
+        // Checks to see if game entity overlaps bounding box of current game entity
         public bool Overlaps(GameEntity entity)
         {
             return _rect.GetGlobalBounds().Intersects(entity.GlobalBounds);
         }
 
-        /// <summary>
-        /// Checks to see if marble entity overlaps bounding box of other game entity
-        /// </summary>
-        /// <param name="entity">game entity to horizontally check overlap (assuming marble coming in from the left)</param>
-        /// <returns>bool</returns>
+        // Checks to see if marble entity overlaps bounding box of other game entity
         public bool MarbleOverlaps(GameEntity entity)
         {
             var entityWithLeftPadding = entity.GlobalBounds;
@@ -116,11 +89,7 @@ namespace MarbleSorterGame.GameEntities
             return _rect.GetGlobalBounds().Intersects(entityWithLeftPadding);
         }
         
-        /// <summary>
-        /// Check to see if entity at any X position intersects this entities Y position (IE a horizontal straight line touches both)
-        /// </summary>
-        /// <param name="entity">game entity to vertically check overlap with</param>
-        /// <returns></returns>
+        // Check to see if entity at any X position intersects this entities Y position (IE a horizontal straight line touches both)
         public bool OverlapsVertical(GameEntity entity)
         {
             float top = GlobalBounds.Top;
@@ -132,22 +101,14 @@ namespace MarbleSorterGame.GameEntities
             return (bottom > eTop && top < eBottom);
         }
         
-        /// <summary>
-        /// Checks whether entity X coordinate fits completely inside this entity
-        /// </summary>
-        /// <param name="entity">game entity to check with</param>
-        /// <returns></returns>
+        // Checks whether entity X coordinate fits completely inside this entity
         public bool InsideHorizontal(GameEntity entity)
         {
             return entity.Position.X < Position.X &&
                 entity.Position.X + entity.Size.X > Position.X + Size.X;
         }
 
-        /// <summary>
-        /// Checks if every point on the entity fit inside of given entity
-        /// </summary>
-        /// <param name="entity">game entity to check with</param>
-        /// <returns></returns>
+        // Checks if every point on the entity fit inside of given entity
         public bool Inside(GameEntity entity)
         {
             var corners = new Vector2f[]
@@ -167,11 +128,7 @@ namespace MarbleSorterGame.GameEntities
             return true;
         }
 
-        /// <summary>
-        /// Checks whether mouse cursor is hovered over the game entity 
-        /// </summary>
-        /// <param name="mousePosition">vector mouse coordinates</param>
-        /// <returns>bool</returns>
+        // Checks whether mouse cursor is hovered over the game entity 
         public bool MouseHovered(Vector2f mousePosition)
         {
             return (
@@ -180,24 +137,15 @@ namespace MarbleSorterGame.GameEntities
                 );
         }
 
-        /// <summary>
-        /// Render method for game entity that draws its bounding box
-        /// </summary>
-        /// <param name="window"></param>
+        // Render method for game entity that draws its bounding box
         public virtual void Render(RenderWindow window)
         {
             window.Draw(_rect);
         }
-        /// <summary>
-        /// Load method for any assets required for the game entity
-        /// </summary>
-        /// <param name="bundle">reference to bundle object containing asset references</param>
+        // Load method for any assets required for the game entity
         public abstract void Load(IAssetBundle bundle);
 
-        /// <summary>
-        /// Shows titlegame entity 
-        /// </summary>
-        /// <returns></returns>
+        // Shows titlegame entity 
         public override string ToString()
         {
             return InfoText;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Gate.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Gate.cs
@@ -5,9 +5,7 @@ using System.Linq;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Simple toggle-able object that moves up and down and lets marble in/out
-    /// </summary>
+    // Simple toggle-able object that moves up and down and lets marble in/out
     public class Gate : GameEntity
     {
         // normal color of gate
@@ -22,7 +20,7 @@ namespace MarbleSorterGame.GameEntities
         public bool IsOpening { get; private set; }
         public bool IsClosing => !IsOpening && !IsFullyOpen && !IsFullyClosed;
 
-        /// How much to in/decrement gate Y-position per-step
+        // How much to in/decrement gate Y-position per-step
         private float Step => Size.Y / GameLoop.FPS / _gatePeriod * (IsOpening ? -1 : 1);
 
         private readonly RectangleShape _gate;
@@ -30,11 +28,7 @@ namespace MarbleSorterGame.GameEntities
          // How many seconds takes for the gate to open. By default, 30 seconds, but source this from Config in .Load()
         private float _gatePeriod = 30f;
 
-        /// <summary>
-        /// Constructor for gate entity
-        /// </summary>
-        /// <param name="position">Global vector coordinates of gate position</param>
-        /// <param name="size">Global vector size of gate</param>
+        // Constructor for gate entity
         public Gate(Vector2f position, Vector2f size) : base(position, size)
         {
             _gate = Box;
@@ -45,19 +39,13 @@ namespace MarbleSorterGame.GameEntities
             _minGateY = position.Y - size.Y;
         }
 
-        /// <summary>
-        /// Sets whether gate is in its moving animation for opening/closing state
-        /// </summary>
-        /// <param name="opening">bool gate state</param>
+        // Sets whether gate is in its moving animation for opening/closing state
         public void SetState(bool opening)
         {
             IsOpening = opening;
         }
 
-        /// <summary>
-        /// Updates movement positioning and gate state for every tick this is called
-        /// </summary>
-        /// <param name="marbles">All marbles that could interact with gate</param>
+        // Updates movement positioning and gate state for every tick this is called
         public void Update(Marble[] marbles)
         {
             if (marbles.Any(InsideHorizontal) && IsClosing)
@@ -74,19 +62,13 @@ namespace MarbleSorterGame.GameEntities
             }
         }
 
-        /// <summary>
-        /// Render method for gate
-        /// </summary>
-        /// <param name="window"></param>
+        // Render method for gate
         public override void Render(RenderWindow window)
         {
             window.Draw(_gate);
         }
 
-        /// <summary>
-        /// Loads assets for gate behaviour, specifically its speed
-        /// </summary>
-        /// <param name="bundle"></param>
+        // Loads assets for gate behaviour, specifically its speed
         public override void Load(IAssetBundle bundle)
         {
             _gatePeriod = bundle.GameConfiguration.GatePeriod;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Label.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Label.cs
@@ -17,7 +17,7 @@ namespace MarbleSorterGame.GameEntities
 
 		private Text _text;
 		public Text LabelText { get => _text; }
-		public Vector2f _labelPosition { get; }
+		private Vector2f _labelPosition { get; }
 		private String _labelText;
 		private int _labelSize;
 		private SFML.Graphics.Color _labelColor;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Label.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Label.cs
@@ -5,10 +5,8 @@ using SFML.Graphics;
 
 namespace MarbleSorterGame.GameEntities
 {
-	/// <summary>
-	/// label is simply a centered text
-	/// Centered text
-	/// </summary>
+	// label is simply a centered text
+	// Centered text
 	public class Label : Drawable
 	{
 		public String Text
@@ -25,14 +23,7 @@ namespace MarbleSorterGame.GameEntities
 		private SFML.Graphics.Color _labelColor;
 		private Font _labelFont;
 
-		/// <summary>
-		/// Constructor for label
-		/// </summary>
-		/// <param name="labelText">String value of what label will output</param>
-		/// <param name="labelPosition">Global vector position</param>
-		/// <param name="labelSize">Global vector size</param>
-		/// <param name="labelColor">Background color of label</param>
-		/// <param name="labelFont">Font of label</param>
+		// Constructor for label
 		public Label(String labelText, Vector2f? labelPosition, int labelSize, SFML.Graphics.Color labelColor, Font labelFont)
 		{
 			_labelText = labelText;
@@ -52,20 +43,13 @@ namespace MarbleSorterGame.GameEntities
 			_text.Position = _labelPosition;
 		}
 
-		/// <summary>
-		/// Draw method of label
-		/// </summary>
-		/// <param name="window">Current drawn window</param>
+		// Draw method of label
 		public void Draw(RenderWindow window)
 		{
 			window.Draw(_text);
 		}
 
-		/// <summary>
-		/// Draw method of label
-		/// </summary>
-		/// <param name="target"></param>
-		/// <param name="states"></param>
+		// Draw method of label
 		public void Draw(RenderTarget target, RenderStates states)
 		{
 			target.Draw(_text);

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Marble.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Marble.cs
@@ -13,10 +13,8 @@ using Color = MarbleSorterGame.Enums.Color;
 namespace MarbleSorterGame
 {
 
-    /// <summary>
-    /// Object that is being sorted in the game
-    /// Rolls right on to the conveyer and is dropped via trapdoors onto the buckets below
-    /// </summary>
+    // Object that is being sorted in the game
+    // Rolls right on to the conveyer and is dropped via trapdoors onto the buckets below
     public class Marble : GameEntity
     {
         private Sprite _sprite;
@@ -34,13 +32,7 @@ namespace MarbleSorterGame
         public static readonly float MarbleSizeSmall = GameLoop.WINDOW_WIDTH / 40f;
 
 
-        /// <summary>
-        /// Constructor for marble
-        /// </summary>
-        /// <param name="screen"></param>
-        /// <param name="position"></param>
-        /// <param name="color"></param>
-        /// <param name="weight"></param>
+        // Constructor for marble
         public Marble(RectangleShape screen, Vector2f position, Color color, Weight weight)//: base(position, size)
         {
             Color = color;
@@ -62,10 +54,7 @@ namespace MarbleSorterGame
             base.Size = size;
         }
 
-        /// <summary>
-        /// Sets state of movement, whether it is moving/falling/stopped
-        /// </summary>
-        /// <param name="state"></param>
+        // Sets state of movement, whether it is moving/falling/stopped
         public void SetState(MarbleState state)
         {
             if (state == MarbleState.Still)
@@ -76,9 +65,7 @@ namespace MarbleSorterGame
                 _velocity = new Vector2f(0,StepY);
         }
         
-        /// <summary>
-        /// Sets marble size
-        /// </summary>
+        // Sets marble size
         public override Vector2f Size
         {
             get => Box.Size;
@@ -89,9 +76,7 @@ namespace MarbleSorterGame
             }
         }
 
-        /// <summary>
-        /// Increment marble position by velocity and rotate accordingly
-        /// </summary>
+        // Increment marble position by velocity and rotate accordingly
         public void Update()
         {
             Position = new Vector2f(Position.X + _velocity.X, Position.Y + _velocity.Y);
@@ -99,10 +84,7 @@ namespace MarbleSorterGame
             _sprite.Rotation += _velocity.X;
         }
 
-        /// <summary>
-        /// Render method for marble
-        /// </summary>
-        /// <param name="window"></param>
+        // Render method for marble
         public override void Render(RenderWindow window)
         {
             //base.Render(window);
@@ -111,10 +93,7 @@ namespace MarbleSorterGame
             window.Draw(_sprite);
         }
 
-        /// <summary>
-        /// Extracts marble texture from bundle from chosen color and scales it correctly to marble dimension
-        /// </summary>
-        /// <param name="bundle"></param>
+        // Extracts marble texture from bundle from chosen color and scales it correctly to marble dimension
         public override void Load(IAssetBundle bundle)
         {
             _marblePeriod = bundle.GameConfiguration.MarblePeriod;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/MotionSensor.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/MotionSensor.cs
@@ -10,9 +10,7 @@ using MarbleSorterGame.Utilities;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Sensor that detects movement of any marble that passes through it
-    /// </summary>
+    // Sensor that detects movement of any marble that passes through it
     public class MotionSensor : Sensor
     {
         public bool Detected { get; set; }
@@ -25,12 +23,7 @@ namespace MarbleSorterGame.GameEntities
         // Note: If laserRange, is negative it detects marbles from the left, vice-versa if positive
         private float _laserRange;
         
-        /// <summary>
-        /// constructor for motion sensor
-        /// </summary>
-        /// <param name="maxLaserRange"></param>
-        /// <param name="position"></param>
-        /// <param name="size"></param>
+        // constructor for motion sensor
         public MotionSensor(float maxLaserRange, Vector2f position, Vector2f size): base(position, size)
         {
             //_sensorSprite.Position = position;
@@ -50,20 +43,14 @@ namespace MarbleSorterGame.GameEntities
                 throw new ArgumentException("Motion Sensor: Detecting motion to right sensor not currently supported!");
         }
 
-        /// <summary>
-        /// Render method for motion sensor
-        /// </summary>
-        /// <param name="window"></param>
+        // Render method for motion sensor
         public override void Render(RenderWindow window)
         {
             base.Render(window);
             window.Draw(_laser);
         }
 
-        /// <summary>
-        /// Perform marble detection and adjust the appearance of the laser
-        /// </summary>
-        /// <param name="marbles">List of all marbles that could be detected by the laser</param>
+        // Perform marble detection and adjust the appearance of the laser
         public void Update(IEnumerable<Marble> marbles)
         {
             if (marbles.Any(m => m.GlobalBounds.Intersects(_laser.GetGlobalBounds())))

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/PressureSensor.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/PressureSensor.cs
@@ -5,18 +5,12 @@ using MarbleSorterGame.Enums;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Sensor that detects weight of marble that passes through it
-    /// </summary>
+    // Sensor that detects weight of marble that passes through it
     public class PressureSensor : Sensor
     {
         Weight Value;
 
-        /// <summary>
-        /// Constructor for pressure sensor
-        /// </summary>
-        /// <param name="position"></param>
-        /// <param name="size"></param>
+        // Constructor for pressure sensor
         public PressureSensor(Vector2f position, Vector2f size) : base(position, size)
         {
             //_sensorSprite.Position = position;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Sensor.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Sensor.cs
@@ -5,9 +5,7 @@ using SFML.System;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Detects characteristics of marble such as weight, color and motion
-    /// </summary>
+    // Detects characteristics of marble such as weight, color and motion
     public abstract class Sensor : GameEntity
     {
         protected Sprite _sensorSprite;
@@ -17,11 +15,7 @@ namespace MarbleSorterGame.GameEntities
         // Perform all IO with the PLC Simulator in SenseCallback handler
         public event EventHandler SenseCallback;
         
-        /// <summary>
-        /// Constructor for sensor
-        /// </summary>
-        /// <param name="position">Global vector position</param>
-        /// <param name="size">Global vector size</param>
+        // Constructor for sensor
         protected Sensor(Vector2f position, Vector2f size) : base(position, size) {
             _sensorSprite = new Sprite();
             _sensorActivate = new Sound();
@@ -30,10 +24,7 @@ namespace MarbleSorterGame.GameEntities
             // Console.WriteLine(_sensorSprite.Position);
         }
 
-        /// <summary>
-        /// Whether sensor has detected a marble passing through it
-        /// </summary>
-        /// <param name="m"></param>
+        // Whether sensor has detected a marble passing through it
         public void Sense(Marble m)
         {
         }
@@ -54,27 +45,19 @@ namespace MarbleSorterGame.GameEntities
             set => _sensorSprite.Position = Box.Position = value;
         }
 
-        /// <summary>
-        /// Plays sensor activation sound
-        /// </summary>
+        // Plays sensor activation sound
         public void playActivateSound()
         {
             _sensorActivate.Play();
         }
 
-        /// <summary>
-        /// Draws sensor onto render target window
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
+        // Draws sensor onto render target window
         public override void Render(RenderWindow window)
         {
             window.Draw(_sensorSprite);
         }
 
-        /// <summary>
-        /// extracts sensor assets from assets bundle
-        /// </summary>
-        /// <param name="bundle">reference to bundle object containing asset references</param>
+        // extracts sensor assets from assets bundle
         public override void Load(IAssetBundle bundle)
         {
             _sensorSprite.Texture = bundle.SensorTexture;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/SignalLight.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/SignalLight.cs
@@ -4,26 +4,16 @@ using SFML.System;
 namespace MarbleSorterGame.GameEntities
 {
 
-    /// <summary>
-    /// Visual indicator of certain toggle-able game entities (such as trapdoors and gates) being in a complete "on" or "off position
-    /// </summary>
+    // Visual indicator of certain toggle-able game entities (such as trapdoors and gates) being in a complete "on" or "off position
     public class SignalLight : GameEntity
     {
-        /// <summary>
-        /// The circle to display on the window
-        /// </summary>
+        // The circle to display on the window
         private readonly CircleShape _signalLight;
         
-        /// <summary>
-        /// Whether the light should be on or off
-        /// </summary>
+        // Whether the light should be on or off
         private bool SignalState { get; set; }
 
-        /// <summary>
-        /// Constructor for signal light
-        /// </summary>
-        /// <param name="position">The position on the window</param>
-        /// <param name="size">The size of the light (unused)</param>
+        // Constructor for signal light
         public SignalLight(Vector2f position, Vector2f size) : base(position, size)
         {
             SignalState = true;
@@ -37,27 +27,18 @@ namespace MarbleSorterGame.GameEntities
             };
         }
 
-        /// <summary>
-        /// Sets state of signal light to be turned on or off
-        /// </summary>
-        /// <param name="state">bool on or off</param>
+        // Sets state of signal light to be turned on or off
         public void SetState(bool state)
         {
             SignalState = state;
         }
         
-        /// <summary>
-        /// Loads any assets used (empty since we are using the built in circle shape)
-        /// </summary>
-        /// <param name="bundle">Assets to load</param>
+        // Loads any assets used (empty since we are using the built in circle shape)
         public override void Load(IAssetBundle bundle)
         {
         }
 
-        /// <summary>
-        /// Draws signal light
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
+        // Draws signal light
         public override void Render(RenderWindow window)
         {
             _signalLight.FillColor = SignalState ? Color.Yellow : Color.Black;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Trapdoor.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Trapdoor.cs
@@ -4,9 +4,7 @@ using SFML.System;
 
 namespace MarbleSorterGame.GameEntities
 {
-    /// <summary>
-    /// Being inline with the conveyer, drops marbles onto buckets below
-    /// </summary>
+    // Being inline with the conveyer, drops marbles onto buckets below
     public class Trapdoor : GameEntity
     {
         private const float _OPEN_MAX_ANGLE = 90f;
@@ -29,10 +27,7 @@ namespace MarbleSorterGame.GameEntities
         public float RotationAngle => _trapdoor.Rotation;
         
 
-        /// <summary>
-        /// Sets state of signal light to be turned on or off
-        /// </summary>
-        /// <param name="opening">Whether trapdoor should be moving in opening/closing</param>
+        // Sets state of signal light to be turned on or off
         public void SetState(bool opening)
         {
             if (opening)
@@ -53,11 +48,7 @@ namespace MarbleSorterGame.GameEntities
             set => Box.Position = _trapdoor.Position = _indicateConveyorDrop.Position = value;
         }
 
-        /// <summary>
-        /// Constructor for trapdoor
-        /// </summary>
-        /// <param name="position">Global vector position</param>
-        /// <param name="size">Global vector size</param>
+        // Constructor for trapdoor
         public Trapdoor(Vector2f position, Vector2f size) : base(position, size)
         {
             _trapdoor = Box;
@@ -71,19 +62,14 @@ namespace MarbleSorterGame.GameEntities
             _indicateConveyorDrop.Position = position;
         }
 
-        /// <summary>
-        /// Rotational movement operation called on every tick
-        /// </summary>
+        // Rotational movement operation called on every tick
         public void Update()
         {
             float newRotation = Math.Min(Math.Max(_CLOSE_MAX_ANGLE, RotationAngle + _rotateStep), _OPEN_MAX_ANGLE);
             _trapdoor.Rotation = newRotation;
         }
 
-        /// <summary>
-        /// Draws trapdoor
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
+        // Draws trapdoor
         public override void Render(RenderWindow window)
         {
             //base.Render(window);
@@ -95,10 +81,7 @@ namespace MarbleSorterGame.GameEntities
                 window.Draw(_indicateConveyorDrop);
         }
 
-        /// <summary>
-        /// Loads assets for trapdoor
-        /// </summary>
-        /// <param name="bundle">reference to bundle object containing asset references</param>
+        // Loads assets for trapdoor
         public override void Load(IAssetBundle bundle)
         {
             _trapDoorPeriod = bundle.GameConfiguration.TrapDoorPeriod;

--- a/src/MarbleSorterGame/MarbleSorterGame/GameLoop.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameLoop.cs
@@ -9,9 +9,7 @@ using SFML.Window;
 
 namespace MarbleSorterGame
 {
-    /// <summary>
-    /// The general structure of how the game is implemented
-    /// </summary>
+    // The general structure of how the game is implemented
     public abstract class GameLoop
     {
         public static int FPS = 60;
@@ -22,9 +20,7 @@ namespace MarbleSorterGame
         public static RectangleShape WINDOW_RECT;
         protected static RenderWindow WINDOW;
         
-        /// <summary>
-        /// Mouse cursor types
-        /// </summary>
+        // Mouse cursor types
         public static class Cursors
         {
             public static readonly Cursor NotAllowed = new Cursor(Cursor.CursorType.NotAllowed);
@@ -32,22 +28,14 @@ namespace MarbleSorterGame
             public static readonly Cursor Arrow = new Cursor(Cursor.CursorType.Arrow);
         }
         
-        /// <summary>
-        /// Color for when the window get cleared
-        /// </summary>
+        // Color for when the window get cleared
         public  SFML.Graphics.Color WindowClearColor
         {
             get;
             protected set;
         }
 
-        /// <summary>
-        /// Game structure that determines how entities are updated and timed
-        /// </summary>
-        /// <param name="windowWidth"></param>
-        /// <param name="windowHeight"></param>
-        /// <param name="windowTitle"></param>
-        /// <param name="windowClearColor"></param>
+        // Game structure that determines how entities are updated and timed
         protected GameLoop(IAssetBundle bundle, string windowTitle, Color windowClearColor)
         {
             WINDOW_WIDTH = bundle?.GameConfiguration?.ScreenWidth ?? 800;
@@ -66,11 +54,9 @@ namespace MarbleSorterGame
             WINDOW.Resized += WINDOW_Resized;
         }
 
-        /// <summary>
-        /// Structure for the game. Assets are first loaded then objects that do not need to change get initialized. The game then loops.
-        /// Inside the loop events get handled, then data gets updated followed by a window clear, redrawing all the object, and then
-        /// displaying new ones. 
-        /// </summary>
+        // Structure for the game. Assets are first loaded then objects that do not need to change get initialized. The game then loops.
+        // Inside the loop events get handled, then data gets updated followed by a window clear, redrawing all the object, and then
+        // displaying new ones. 
         public void Run()
         {
             while (WINDOW.IsOpen)
@@ -84,27 +70,17 @@ namespace MarbleSorterGame
             }
         }
 
-        /// <summary>
-        /// Abstract method for inheritors to implement
-        /// </summary>
+        // Abstract method for inheritors to implement
         public abstract void Update();
         public abstract void Draw();
 
-        /// <summary>
-        /// Event handler for window closing (through clicking the X button)
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
+        // Event handler for window closing (through clicking the X button)
         private void WINDOW_Closed(object sender, EventArgs e)
         {
             WINDOW.Close();
         }
         
-        /// <summary>
-        /// Event handler for window resizing
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
+        // Event handler for window resizing
         private void WINDOW_Resized(object sender, SizeEventArgs e)
         {
             WINDOW.SetView(new View(new FloatRect(0, 0, e.Width, e.Height)));

--- a/src/MarbleSorterGame/MarbleSorterGame/IAssetBundle.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/IAssetBundle.cs
@@ -6,9 +6,7 @@ using SFML.Window;
 
 namespace MarbleSorterGame
 {
-    /// <summary>
-    /// interface for all available bundled assets required for game
-    /// </summary>
+    // interface for all available bundled assets required for game
     public interface IAssetBundle
     {
         public Sound BucketDrop { get; set; }

--- a/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.cs
@@ -8,9 +8,7 @@ using SFML.Window;
 
 namespace MarbleSorterGame
 {
-    /// <summary>
-    /// The implementation of the abstract game loop 
-    /// </summary>
+    // The implementation of the abstract game loop 
     public class MarbleSorterGame : GameLoop
     {
         private static string WINDOW_TITLE = "PLC Training Simulator - Marble Sorter Game";
@@ -36,12 +34,7 @@ namespace MarbleSorterGame
             ActiveMenu = Menu.Main;
         }
 
-        /// <summary>
-        /// Trigger click event(s) on buttons if a click event occured there
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="buttons">All buttons that could be clicked on</param>
-        /// <param name="mouse">Mouse object</param>
+        // Trigger click event(s) on buttons if a click event occured there
         public static void UpdateButtonsFromClickEvent(object? sender, GameEntities.Button[] buttons, MouseButtonEventArgs mouse)
         {
             foreach (var button in buttons)
@@ -50,12 +43,7 @@ namespace MarbleSorterGame
         }
 
 
-        /// <summary>
-        /// Update the state of buttons/cursor based on mouse event and list of buttons
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
-        /// <param name="buttons">All buttons that could be hovered over on</param>
-        /// <param name="mouse">Mouse object</param>
+        // Update the state of buttons/cursor based on mouse event and list of buttons
         public static void UpdateButtonsFromMouseEvent(RenderWindow window, GameEntities.Button[] buttons, MouseMoveEventArgs mouse)
         {
             window.SetMouseCursor(Cursors.Arrow);
@@ -70,17 +58,13 @@ namespace MarbleSorterGame
             }
         }
 
-        /// <summary>
-        /// Update any data for the game
-        /// </summary>
+        // Update any data for the game
         public override void Update()
         {
             _activeScreen.Update();
         }
 
-        /// <summary>
-        /// Draw method for the game. Each of the screens call their draw method depending on the active menu
-        /// </summary>
+        // Draw method for the game. Each of the screens call their draw method depending on the active menu
         public override void Draw()
         {
             _activeScreen.Draw(WINDOW);

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/GameScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/GameScreen.cs
@@ -11,9 +11,7 @@ using Color = SFML.Graphics.Color;
 
 namespace MarbleSorterGame.Screens
 {
-    /// <summary>
-    /// The game itself
-    /// </summary>
+    // The game itself
     public class GameScreen : Screen, IDisposable
     {
         private RenderWindow _window;
@@ -339,40 +337,26 @@ namespace MarbleSorterGame.Screens
             _buckets[2].InfoText = "Bucket 3 \n %I1.0 Bool";
         }
 
-        /// <summary>
-        /// Mouse movement event handler for features involving hover-over
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="mouse"></param>
+        // Mouse movement event handler for features involving hover-over
         private void GameMouseMoveEventHandler(object? sender, MouseMoveEventArgs mouse)
         {
             MarbleSorterGame.UpdateButtonsFromMouseEvent(_window, _buttons, mouse);
         }
 
-        /// <summary>
-        /// Mouse click event handler for button clicking
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="mouse"></param>
+        // Mouse click event handler for button clicking
         private void GameMouseClickEventHandler(object? sender, MouseButtonEventArgs mouse)
         {
             MarbleSorterGame.UpdateButtonsFromClickEvent(sender, _buttons, mouse);
         }
 
-        /// <summary>
-        /// Keyboard event handlers for keyboard driver, for debug purposes
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="key"></param>
+        // Keyboard event handlers for keyboard driver, for debug purposes
         private void GameKeyEventHandler(object? sender, KeyEventArgs key)
         {
             if (_driver is KeyboardIODriver kbdriver)
                 kbdriver.UpdateByKey(key);
         }
 
-        /// <summary>
-        /// Writes driver values to the game and reads in game state 
-        /// </summary>
+        // Writes driver values to the game and reads in game state 
         private void UpdateDriver()
         {
             _gateEntrance.SetState(_driver.Gate);
@@ -392,8 +376,8 @@ namespace MarbleSorterGame.Screens
             _trapDoorsClosed[1].SetState(_trapDoors[1].IsFullyClosed);
             _trapDoorsClosed[2].SetState(_trapDoors[2].IsFullyClosed);
             
-            //////////////////////////////////////////////////////////// 
-            /////// BEGIN: TODO FIXME HACK
+            //////////////////////////////////////// 
+            ///// BEGIN: TODO FIXME HACK
 
             // This is code that gets the sensors working for the demo presentation
             // It simply checks if a marble overlaps the sensor, if yes, write the value to the driver
@@ -423,16 +407,14 @@ namespace MarbleSorterGame.Screens
             _motionSensorBucket.Update(_marbles);
             _driver.BucketMotionSensor |= _motionSensorBucket.Detected;
             
-            //////// END: TODO FIXME HACK
-            ////////////////////////////////////////////////////////////
+            ////// END: TODO FIXME HACK
+            ////////////////////////////////////////
 
             // Update IIODriver instance
             _driver.Update();
         }
 
-        /// <summary>
-        /// Update marble positioning
-        /// </summary>
+        // Update marble positioning
         private void UpdateMarbles()
         {
             foreach (var marble in _marbles)
@@ -491,9 +473,7 @@ namespace MarbleSorterGame.Screens
             }
         }
 
-        /// <summary>
-        /// Update door positions
-        /// </summary>
+        // Update door positions
         private void UpdateDoors()
         {
             foreach (var trapdoor in _trapDoors)
@@ -503,9 +483,7 @@ namespace MarbleSorterGame.Screens
             _gateEntrance.Update(_marbles);
         }
 
-        /// <summary>
-        /// Update legend text
-        /// </summary>
+        // Update legend text
         private void UpdateLegend()
         {
             _legendData["Currently Hovered Item"] = _hoveredEntity == null ? "N/A" : _hoveredEntity.InfoText;
@@ -529,9 +507,7 @@ namespace MarbleSorterGame.Screens
             _legendBackground.Size = new Vector2f(legendBounds.Width + _legendPadding*4, legendBounds.Height + _legendPadding*2);
         }
 
-        /// <summary>
-        /// Update game state from key events such as bucket handling and win state
-        /// </summary>
+        // Update game state from key events such as bucket handling and win state
         public void UpdateGameState()
         {
             _marblesRemaining = _marblesTotal - _buckets.Select(b => b.TotalMarbles).Sum();
@@ -559,9 +535,7 @@ namespace MarbleSorterGame.Screens
                 _gameState = GameState.Lose;
         }
 
-        /// <summary>
-        /// Update all game entity positions, game state and driver input/output
-        /// </summary>
+        // Update all game entity positions, game state and driver input/output
         public override void Update()
         {
             UpdateLegend();
@@ -575,10 +549,7 @@ namespace MarbleSorterGame.Screens
             }
         }
         
-        /// <summary>
-        /// Redraw screen in preparation for next update loop
-        /// </summary>
-        /// <param name="window"></param>
+        // Redraw screen in preparation for next update loop
         public override void Draw(RenderWindow window)
         {
             foreach (var drawable in _drawables)
@@ -588,11 +559,7 @@ namespace MarbleSorterGame.Screens
                 entity.Render(window);
         }
 
-        /// <summary>
-        /// Event handler for pause button click
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="args"></param>
+        // Event handler for pause button click
         private void PauseButtonClickHandler(object? sender, MouseButtonEventArgs args)
         {
             if (_gameState == GameState.Pause)
@@ -604,31 +571,21 @@ namespace MarbleSorterGame.Screens
             //   s7driver.SetRunState(true);
         }
 
-        /// <summary>
-        /// Event handler for reset button click
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="args"></param>
+        // Event handler for reset button click
         private void ResetButtonClickHandler(object? sender, MouseButtonEventArgs args)
         {
             Dispose();
             Reset();
         }
 
-        /// <summary>
-        /// Event handler for main menu button click
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="args"></param>
+        // Event handler for main menu button click
         private void MainMenuButtonClickHandler(object? sender, MouseButtonEventArgs args)
         {
             Dispose();
             MarbleSorterGame.ActiveMenu = Menu.Main;
         }
 
-        /// <summary>
-        /// Dispose all event handlers associated with the game screen
-        /// </summary>
+        // Dispose all event handlers associated with the game screen
         public void Dispose()
         {
             _buttonPause.ClickEvent -= PauseButtonClickHandler;

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/MainScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/MainScreen.cs
@@ -12,9 +12,7 @@ using Color = SFML.Graphics.Color;
 
 namespace MarbleSorterGame.Screens
 {
-    /// <summary>
-    /// The main page where users can go to the setting screen or the game
-    /// </summary>
+    // The main page where users can go to the setting screen or the game
     public class MainScreen : Screen, IDisposable
     {
         private Font _font;
@@ -87,9 +85,7 @@ namespace MarbleSorterGame.Screens
             }
             
         }
-        /// <summary>
-        /// Initializes all event handlers associated with main screen
-        /// </summary>
+        // Initializes all event handlers associated with main screen
         private void SetupInputHandlers()
         {
             _window.MouseButtonPressed += MenuMousePressed;
@@ -99,61 +95,39 @@ namespace MarbleSorterGame.Screens
             _buttonExit.ClickEvent += ExitButtonClickHandler;
         }
 
-        /// <summary>
-        /// Event handler for start button click
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="mouse"></param>
+        // Event handler for start button click
         private void StartButtonClickHandler(object? sender, MouseButtonEventArgs mouse)
         {
             MarbleSorterGame.ActiveMenu = Menu.Game;
             Dispose();
         }
 
-        /// <summary>
-        /// Event handler for settings button click
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="mouse"></param>
+        // Event handler for settings button click
         private void SettingsButtonClickHandler(object? sender, MouseButtonEventArgs mouse)
         {
             MarbleSorterGame.ActiveMenu = Menu.Settings;
             Dispose();
         }
 
-        /// <summary>
-        /// Event handler for exit button click
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="mouse"></param>
+        // Event handler for exit button click
         private void ExitButtonClickHandler(object? sender, MouseButtonEventArgs mouse)
         {
             _window.Close();
         }
 
-        /// <summary>
-        /// Event handler for mouse click, check if any of menu buttons were clicked from that
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="mouse"></param>
+        // Event handler for mouse click, check if any of menu buttons were clicked from that
          private void MenuMousePressed(object? sender, MouseButtonEventArgs mouse)
         {
             MarbleSorterGame.UpdateButtonsFromClickEvent(sender, _buttons, mouse);
         }
          
-        /// <summary>
-        /// Event handler for mouse hover-over 
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="mouse"></param>
+        // Event handler for mouse hover-over 
         private void MouseHoverOverButton(object? sender, MouseMoveEventArgs mouse)
         {
             MarbleSorterGame.UpdateButtonsFromMouseEvent(_window, _buttons, mouse);
         }
 
-        /// <summary>
-        /// Updates positions of game entities and game state logic
-        /// </summary>
+        // Updates positions of game entities and game state logic
         public override void Update()
         {
             float xOffset = default;
@@ -168,10 +142,7 @@ namespace MarbleSorterGame.Screens
             }
         }
 
-        /// <summary>
-        /// Redraw screen in preparation for next update loop
-        /// </summary>
-        /// <param name="window"></param>
+        // Redraw screen in preparation for next update loop
         public override void Draw(RenderWindow window)
         {
             if (_errorMode)
@@ -195,9 +166,7 @@ namespace MarbleSorterGame.Screens
             }
         }
 
-        /// <summary>
-        /// Dispose all event handlers associated with the menu screen
-        /// </summary>
+        // Dispose all event handlers associated with the menu screen
         public void Dispose()
         {
             _window.MouseButtonPressed -= MenuMousePressed;

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/MainScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/MainScreen.cs
@@ -67,14 +67,14 @@ namespace MarbleSorterGame.Screens
                 Vector2f buttonSize = screen.Percent(15f, 10f); // new Vector2f(window.Size.X / 7, window.Size.Y / 11);
                 _buttonStart = new Button("Start", 0.7f, _font, screen.Percent(30f, 70f), buttonSize);
                 _buttonSettings = new Button("Settings",0.7f,  _font, screen.Percent(50f, 70f), buttonSize);
-                _buttonSettings.Disabled = true;
+                //_buttonSettings.Disabled = true;
                 _buttonExit = new Button("Exit", 0.7f, _font, screen.Percent(70f, 70f), buttonSize);
                 _buttons = new [] { _buttonStart, _buttonSettings, _buttonExit };
 
                 Enums.Color[] colors = {Enums.Color.Red, Enums.Color.Green, Enums.Color.Blue};
                 for (int i = 0; i < 3; i++)
                 {
-                    var marble = new Marble(screen, default, colors[i], Weight.Large);
+                    var marble = new Marble(screen, new Vector2f(-1000, -1000), colors[i], Weight.Large);
                     marble.SetState(MarbleState.Rolling);
                     marble.Load(bundle);
                     marble.Size = _marbleSize;

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/Screen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/Screen.cs
@@ -3,20 +3,13 @@ using SFML.Graphics;
 
 namespace MarbleSorterGame.Screens
 {
-    /// <summary>
-    /// General window state that points to other screens
-    /// </summary>
+    // General window state that points to other screens
     public abstract class Screen
     {
-        /// <summary>
-        /// Updates any game entity positions, game logic and driver states
-        /// </summary>
+        // Updates any game entity positions, game logic and driver states
         public abstract void Update();
         
-        /// <summary>
-        /// Draws any game entities to the current window
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
+        // Draws any game entities to the current window
         public abstract void Draw(RenderWindow window);
     }
 }

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/SettingsScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/SettingsScreen.cs
@@ -39,7 +39,7 @@ namespace MarbleSorterGame.Screens
             var buttonSize = screen.Percent(20, 8);
             var buttonPosition = screen.PositionRelative(Joint.End, Joint.Start).ShiftX(-buttonSize.X).ShiftY(buttonSize.Y);
             
-            _returnButton = new Button("Return to Menu", 0.7f, bundle.Font, buttonPosition, buttonSize);
+            _returnButton = new Button("Return to Menu", 0.5f, bundle.Font, buttonPosition, buttonSize);
             _returnButton.ClickEvent += ReturnButtonClickHandler;
             _buttons = new[] { _returnButton } ;
 
@@ -47,8 +47,8 @@ namespace MarbleSorterGame.Screens
             string gamePath = Path.Join(dirPath, "game.json");
             var editNotePosition = screen
                 .PositionRelative(Joint.Middle, Joint.Start)
-                .ShiftY(_returnButton.Box.Position.Y + 30 + buttonSize.Y);
-            _editNote = new Label($"Edit the following file to change game settings:\n\n{gamePath.ColumnWrap(80).Replace("\t", "")}", editNotePosition, 24, Color.Red, bundle.Font);
+                .ShiftY(_returnButton.Box.Position.Y + 60 + buttonSize.Y);
+            _editNote = new Label($"Edit the following file to change game settings:\n\n{gamePath.ColumnWrap(60).Replace("\t", "")}", editNotePosition, 16, Color.Red, bundle.Font);
             
             var conf = bundle.GameConfiguration;
             string settingsText = string.Join("\n", new[]
@@ -66,7 +66,7 @@ namespace MarbleSorterGame.Screens
             
             var settingsPosition = screen.PositionRelative(Joint.Middle, Joint.Middle);
             settingsPosition.Y = _editNote.LabelText.Position.Y + _editNote.LabelText.GetGlobalBounds().Height + 30;
-            _settings = new Label(settingsText, settingsPosition, 32, Color.Black, bundle.Font);
+            _settings = new Label(settingsText, settingsPosition, 26, Color.Black, bundle.Font);
             _settings.LabelText.Position += new Vector2f(0, _settings.LabelText.GetGlobalBounds().Height / 2);
         }
 

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/SettingsScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/SettingsScreen.cs
@@ -58,6 +58,7 @@ namespace MarbleSorterGame.Screens
                 "",
                 $"Driver: {conf.Driver}",
                 $"Simulation Name: {conf.DriverOptions?.SimulationName}",
+                $"Update Interval: {conf.DriverOptions?.UpdateInterval}",
                 "",
                 $"Gate Period: {conf.GatePeriod}",
                 $"Marble Period: {conf.MarblePeriod}",

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/SettingsScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/SettingsScreen.cs
@@ -5,34 +5,22 @@ using SFML.System;
 
 namespace MarbleSorterGame.Screens
 {
-    /// <summary>
-    /// The settings screen
-    /// </summary>
+    // The settings screen
     public class SettingsScreen : Screen
     {
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="window">Current window to draw</param>
-        /// <param name="bundle">reference to bundle object containing asset references</param>
+        // Constructor
         public SettingsScreen(RenderWindow window, IAssetBundle bundle)
         {
             Font font = bundle.Font;
         }
         
-        /// <summary>
-        /// Updates any game states changed by the setting
-        /// </summary>
+        // Updates any game states changed by the setting
         public override void Update()
         {
             
         }
 
-        /// <summary>
-        /// Method that gets called when the screen is to be redrawn
-        /// </summary>
-        /// <param name="window"></param>
-        /// <param name="font"></param>
+        // Method that gets called when the screen is to be redrawn
         public override void Draw(RenderWindow window)
         {
             //default sizes

--- a/src/MarbleSorterGame/MarbleSorterGame/Utilities/QuickShape.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Utilities/QuickShape.cs
@@ -3,9 +3,7 @@ using SFML.System;
 
 namespace MarbleSorterGame.Utilities
 {
-    /// <summary>
-    /// Contains convenience methods for constructing commonly use game shapes/drawables
-    /// </summary>
+    // Contains convenience methods for constructing commonly use game shapes/drawables
     public static class QuickShape
     {
         public static Text Label(string displayString, Vector2f position, Font font, SFML.Graphics.Color color)

--- a/src/MarbleSorterGame/MarbleSorterGame/Utilities/UtilityCentering.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Utilities/UtilityCentering.cs
@@ -3,9 +3,7 @@ using SFML.Graphics;
 
 namespace MarbleSorterGame.Utilities
 {
-    /// <summary>
-    /// sets transformable origin of shape/text to its rectangular center
-    /// </summary>
+    // sets transformable origin of shape/text to its rectangular center
     public static class UtilityCentering
     {
         public static Vector2f CenterOrigin(this Shape entity)


### PR DESCRIPTION
Adds a new field to driver options. This is how many updates/screen refreshes the game will make before reading/writing loaded values from/to the simulation.

Lower this value to decrease CPU usage. Increase this value to have less IO latency between game and PLC.

Closes #46 

![image](https://user-images.githubusercontent.com/8365778/112913616-0532b400-90c8-11eb-84f5-f480c1351088.png)
