### PR TITLE
Refactor legend code, various positioning fixes, error catching and marble counting improvements

### DIFF
--- a/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
@@ -177,6 +177,10 @@ namespace MarbleSorterGame
         public string Type { get; set; }
         public byte BitSize { get; set; }
         public string Description { get; set; }
+        public string ToAddressString()
+        {
+            return $"%{MemoryArea}{Byte}.{Bit}"; // Eg. %Q1.0
+        }
     }
 
     // Represent a marble/bucket game configuration

--- a/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Configuration.cs
@@ -151,8 +151,8 @@ namespace MarbleSorterGame
 
         public void Validate()
         {
-            ValidateProperty(ScreenHeight < 600, "ScreenHeight", "Must be >= 600");
-            ValidateProperty(ScreenWidth < 800, "ScreenWidth", "Must be >= 800");
+            ValidateProperty(ScreenHeight < 720, "ScreenHeight", "Must be >= 720");
+            ValidateProperty(ScreenWidth < 1280, "ScreenWidth", "Must be >= 1280");
             ValidateProperty(MarblePeriod <= 0, "MarblePeriod", "Must be > 0");
             ValidateProperty(GatePeriod <= 0, "GatePeriod", "Must be > 0");
             ValidateProperty(TrapDoorPeriod <= 0, "TrapDoorPeriod", "Must be > 0");

--- a/src/MarbleSorterGame/MarbleSorterGame/Enums/GameState.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Enums/GameState.cs
@@ -7,4 +7,29 @@ namespace MarbleSorterGame.Enums
         Progress,
         Pause
     }
+
+    public static class GameStateEnumExtensions 
+    {
+        public static string ToHumanString(this GameState self)
+        {
+            return self switch
+            {
+                GameState.Lose => "You Lost!",
+                GameState.Win => "You Won!",
+                GameState.Progress => "In-Progress",
+                GameState.Pause => "Paused",
+            };
+        }
+        
+        public static SFML.Graphics.Color ToIndicatorColor(this GameState self)
+        {
+            return self switch
+            {
+                GameState.Lose => SFML.Graphics.Color.Red,
+                GameState.Win => SFML.Graphics.Color.Green,
+                GameState.Progress => SFML.Graphics.Color.Yellow,
+                GameState.Pause => SFML.Graphics.Color.Cyan,
+            };
+        }
+    }
 }

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Bucket.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Bucket.cs
@@ -50,6 +50,9 @@ namespace MarbleSorterGame.GameEntities
 
             TotalCorrect = 0;
             TotalIncorrect = 0;
+
+            string plural = capacity > 1 ? "s" : "";
+            Name = $"Bucket Requires {capacity} {requiredColor} {requiredWeight} Marble{plural}".Replace("  ", " ");
         }
 
         public override Vector2f Position

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Gate.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Gate.cs
@@ -9,7 +9,7 @@ namespace MarbleSorterGame.GameEntities
     public class Gate : GameEntity
     {
         // normal color of gate
-        private static readonly Color DefaultGateColor = Color.Black;
+        private static readonly Color DefaultGateColor = new Color(61, 66, 87); // Color.Black;
         // Color of gate when a marble is stuck underneath
         private static readonly Color JammedGateColor = Color.Red;
 

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Legend.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Legend.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Runtime.InteropServices.WindowsRuntime;
+using MarbleSorterGame.Utilities;
+using SFML.Graphics;
+using SFML.System;
+
+namespace MarbleSorterGame.GameEntities
+{
+    // is text centered on a colored background (rectangle) with padding. the background will grow/shrink to match currently loaded text
+    public class Legend : GameEntity
+    {
+        private Text _text;
+        private uint _padding;
+        private uint _outlineThickness;
+        private RectangleShape _background;
+        public bool Hidden { get; set; }
+        
+        // get or set text displayed in legend and resize background to fit
+        public string DisplayedText
+        {
+            get => _text.DisplayedString;
+            set {  
+                _text.DisplayedString = value;
+                Refit();
+            }
+        }
+
+        // get or set background color of legend
+        public SFML.Graphics.Color BackgroundColor
+        {
+            get => _background.FillColor;
+            set => _background.FillColor = value;
+        }
+
+        public override Vector2f Size
+        {
+            get => Box.Position;
+            set => throw new NotImplementedException("Cannot resize legend - operation unimplemented");
+        }
+        public override Vector2f Position 
+        {
+            get => base.Position;
+            set
+            {
+                 base.Position = value;
+                 Refit();
+            } 
+        }
+
+        // adjust the size of background to accommodate text content
+        private void Refit()
+        {
+            _text.Position = base.Position;
+            _background.Position = base.Position;
+            _background.Size = new Vector2f(_text.GetGlobalBounds().Width, _text.GetGlobalBounds().Height);
+            _background.Size += new Vector2f(_padding + _outlineThickness, _padding + _outlineThickness);
+            _text.Position = _background.Position
+                .ShiftX(_padding/2f)
+                .ShiftY(_padding/2f);
+        }
+
+        public Legend(string text, uint characterSize, uint padding, Color backgroundColor, Color outlineColor, uint outlineThickness, Font font, Vector2f position)
+        {
+            _padding = padding;
+            _outlineThickness = outlineThickness;
+            _background = Box;
+            _background.FillColor = backgroundColor;
+            _background.OutlineThickness = outlineThickness;
+            _background.OutlineColor = outlineColor;
+
+            _text = new Text(text, font, characterSize);
+            _text.FillColor = Color.Black;
+            base.Position = position;
+            Refit();
+        }
+        
+        public override void Render(RenderWindow window)
+        {
+            //base.Render(window);
+            if (!Hidden)
+            {
+                window.Draw(_background);
+                window.Draw(_text);
+            }
+        }
+
+        public override void Load(IAssetBundle bundle)
+        {
+        }
+    }
+}

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Marble.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Marble.cs
@@ -31,9 +31,8 @@ namespace MarbleSorterGame
         public static readonly float MarbleSizeMedium = GameLoop.WINDOW_WIDTH / 30f;
         public static readonly float MarbleSizeSmall = GameLoop.WINDOW_WIDTH / 40f;
 
-
         // Constructor for marble
-        public Marble(RectangleShape screen, Vector2f position, Color color, Weight weight)//: base(position, size)
+        public Marble(Vector2f position, Color color, Weight weight)//: base(position, size)
         {
             Color = color;
             Weight = weight;
@@ -52,6 +51,8 @@ namespace MarbleSorterGame
             Position = position;
             Radius = size.X / 2;
             base.Size = size;
+
+            Name = $"{weight} {color} Marble";
         }
 
         // Sets state of movement, whether it is moving/falling/stopped

--- a/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Trapdoor.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/GameEntities/Trapdoor.cs
@@ -21,8 +21,8 @@ namespace MarbleSorterGame.GameEntities
         private RectangleShape _indicateConveyorDrop;
         
         public bool IsOpen => RotationAngle > _DROP_ANGLE && RotationAngle <= _OPEN_MAX_ANGLE + 1f;
-        public bool IsFullyOpen => RotationAngle == 90;
-        public bool IsFullyClosed => RotationAngle == 0;
+        public bool IsFullyOpen => RotationAngle == 0;
+        public bool IsFullyClosed => RotationAngle == 90;
 
         public float RotationAngle => _trapdoor.Rotation;
         

--- a/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.cs
@@ -23,13 +23,22 @@ namespace MarbleSorterGame
         {
             set
             {
-                _activeGameScreen = value switch
+                try
                 {
-                    Menu.Game => new MarbleSorterGameScreen(WINDOW, _bundle, _driver),
-                    Menu.Main => new MainMenuGameScreen(WINDOW, _bundle),
-                    Menu.Settings => new SettingsGameScreen(WINDOW, _bundle),
-                    Menu.Error => new ErrorGameScreen(WINDOW, Error) 
-                };
+                    _activeGameScreen = value switch
+                    {
+                        Menu.Game => new MarbleSorterGameScreen(WINDOW, _bundle, _driver),
+                        Menu.Main => new MainMenuGameScreen(WINDOW, _bundle),
+                        Menu.Settings => new SettingsGameScreen(WINDOW, _bundle),
+                        Menu.Error => new ErrorGameScreen(WINDOW, Error) 
+                    };
+                }
+                catch (Exception exception)
+                {
+                    Console.WriteLine(exception);
+                    Error = exception.ToString();
+                    _activeGameScreen = new ErrorGameScreen(WINDOW, Error);
+                }
             }
         }
         

--- a/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.cs
@@ -1,12 +1,7 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using MarbleSorterGame.Enums;
 using MarbleSorterGame.Screens;
-using MarbleSorterGame.Utilities;
-using SFML.Graphics;
-using SFML.System;
-using SFML.Window;
 
 namespace MarbleSorterGame
 {

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/MainMenuScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/MainMenuScreen.cs
@@ -46,7 +46,7 @@ namespace MarbleSorterGame.Screens
             Enums.Color[] colors = {Enums.Color.Red, Enums.Color.Green, Enums.Color.Blue};
             for (int i = 0; i < 3; i++)
             {
-                var marble = new Marble(Screen, new Vector2f(-1000, -1000), colors[i], Weight.Large);
+                var marble = new Marble(new Vector2f(-1000, -1000), colors[i], Weight.Large);
                 marble.SetState(MarbleState.Rolling);
                 marble.Load(bundle);
                 marble.Size = _marbleSize;

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/MarbleSorterScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/MarbleSorterScreen.cs
@@ -48,37 +48,31 @@ namespace MarbleSorterGame.Screens
         private Button _buttonReset;
         private Button _buttonMainMenu;
         private Button[] _buttons;
+        private RectangleShape _menuBarBackground;
 
-        // Win/Lose boxes
-        private RectangleShape _winPopupBox;
-        private RectangleShape _losePopupBox;
-        private Label _winPopup;
-        private Label _losePopup;
-
-        // Infobox helper text
-        private Vector2f _infoBoxBackgroundSize;
+        // Legends
+        private Legend _legendHovered;
         private GameEntity _hoveredEntity;
-        private RectangleShape _infoBoxBackground;
-        private Label _infoLabel;
-        private Dictionary<string, string> _infoData;
+        private Dictionary<string, string> _hoveredEntityData;
 
-        // Legend area
-        private Dictionary<string, string> _IOMapping;
-        private Label _legendGame;
-        private Label _legendMapping;
-        private RectangleShape _legendGameBackground;
-        private RectangleShape _legendMappingBackground;
-        private Dictionary<string, string> _legendGameData;
-        private Dictionary<string, string> _legendMappingData;
-        private readonly float _legendPadding = 5;
+        private Legend _legendGameState; // reflects _gameState
         
-        // Game screen state
+        private Legend _legendGame;
+        private Dictionary<string, string> _legendGameData;
+        
+        private Legend _legendIoMap;
+        private Dictionary<string, string> _ioMapData;
+        
+        private readonly uint _legendPadding = 20;
+        private readonly float _legendSpacing;
+
+        // Game state
         private GameState _gameState;
-        private int _marblesTotal;
-        private int _marblesRemaining;
+        private List<Marble> _marblesRemaining;
         
         public MarbleSorterGameScreen(RenderWindow window, IAssetBundle bundle, IIODriver driver) : base(window, bundle)
         {
+            _legendSpacing = Screen.Percent(0, 1).Y; // 1% vertical distance between other legends and menu bar background
             _driver = driver;
             Reset();
         }
@@ -90,13 +84,11 @@ namespace MarbleSorterGame.Screens
             var font = Bundle.Font;
             var preset = Bundle.GameConfiguration.Preset;
 
-            _IOMapping = new Dictionary<string, string>();
+            _ioMapData = new Dictionary<string, string>();
             _legendGameData = new Dictionary<string, string>();
-            _marblesTotal = preset.Marbles.Count;
-            _marblesRemaining = _marblesTotal;
+            _hoveredEntityData = new Dictionary<string, string>();
+            
             _gameState = GameState.Progress;
-
-            _infoData = new Dictionary<string, string>();
 
             //================= Event Handlers ====================//
             Window.MouseButtonPressed += GameMouseClickEventHandler;
@@ -108,7 +100,7 @@ namespace MarbleSorterGame.Screens
             var chromeColor = new SFML.Graphics.Color(218, 224, 226);
 
             // Menu bar background (slight gray recantgle behind buttons)
-            RectangleShape menuBarBackground = new RectangleShape
+            _menuBarBackground = new RectangleShape
             {
                 Position = new Vector2f(),
                 Size = Screen.Percent(100f, 6f),
@@ -121,6 +113,7 @@ namespace MarbleSorterGame.Screens
 
             Vector2f menuButtonSize = Screen.Percent(8, 4);
             float menuButtonFontScale = 0.4f;
+            float menuButtonSpacing = new Vector2f().PercentOfX(Screen, 1f).X;
             
             _buttonPause = new Button("Pause", menuButtonFontScale, font, default, menuButtonSize);
             _buttonReset = new Button("Reset Game", menuButtonFontScale, font, default, menuButtonSize);
@@ -130,18 +123,18 @@ namespace MarbleSorterGame.Screens
             _buttonMainMenu.Position = Screen
                 .PositionRelative(Joint.End, Joint.Start) // Position top corner of screen
                 .ShiftX(-menuButtonSize.X/2) // Shift left so its not over screen edge
-                .ShiftX(-new Vector2f().PercentOfX(Screen, 1f).X) // Add a 1% spacer from screen edge
-                .ShiftY((menuButtonSize.Y)/2 + Math.Max(0, menuBarBackground.Size.Y - menuButtonSize.Y)/2); // Shift down so its vertically centered in menu bar background
+                .ShiftX(-menuButtonSpacing) // Add a 1% spacer from screen edge
+                .ShiftY((menuButtonSize.Y)/2 + Math.Max(0, _menuBarBackground.Size.Y - menuButtonSize.Y)/2); // Shift down so its vertically centered in menu bar background
 
             _buttonReset.Position = _buttonMainMenu.Box
                 .PositionRelative(Joint.Start, Joint.Start)
                 .ShiftX(-menuButtonSize.X)
-                .ShiftX(-new Vector2f().PercentOfX(Screen, 1f).X); // Add a 1% spacer from button edge
+                .ShiftX(-menuButtonSpacing); // Add a 1% spacer from button edge
             
             _buttonPause.Position = _buttonReset.Box
                 .PositionRelative(Joint.Start, Joint.Start)
                 .ShiftX(-menuButtonSize.X)
-                .ShiftX(-new Vector2f().PercentOfX(Screen, 1f).X); // Add a 1% spacer from button edge
+                .ShiftX(-menuButtonSpacing); // Add a 1% spacer from button edge
 
             _buttonPause.ClickEvent += PauseButtonClickHandler;
             _buttonReset.ClickEvent += ResetButtonClickHandler;
@@ -149,83 +142,37 @@ namespace MarbleSorterGame.Screens
             
             _buttons = new[] { _buttonMainMenu, _buttonPause, _buttonReset};
 
-            //================= Labels ====================//
-            // string instructionsText = "Use the Input/Output Addresses shown below to create a working \nPLC for the marble sorter, based on the requirements on the buckets below.";
-            // //Label instructions = new Label(instructionsText,screen.Percent(0, 3), 14, SFML.Graphics.Color.Black, font);
-            // var instructions = QuickShape.Label(instructionsText, new Vector2f(0, 0), font, Color.Black);
-            // instructions.Scale = new Vector2f(0.5f, 0.5f);
-            // var gameScreenTitle = QuickShape.Label("Marble Sorter", new Vector2f(0, 0), font, Color.Black);
+            var legendGamePosition = _menuBarBackground
+                .PositionRelative(Joint.Start, Joint.End)
+                .Shift(new Vector2f(_legendSpacing, _legendSpacing));
+            
+            _legendGame = new Legend(string.Empty, 14, _legendPadding, chromeColor, Color.Black, 2, Bundle.Font, legendGamePosition);
 
-            var legendBackgroundSize = Screen.Percent(50f, 40f);
-            _legendGameBackground = new RectangleShape
-            {
-                Size = legendBackgroundSize,
-                FillColor = chromeColor,
-                OutlineColor = Color.Black,
-                OutlineThickness = 2,
-                //Position = menuBarBackground.PositionRelative(Joint.End, Joint.End).ShiftX(-legendBackgroundSize.X)
-                Position = menuBarBackground.PositionRelative(Joint.Start, Joint.End)
-                    .ShiftX(Screen.Percent(0, 1).Y)
-                    .ShiftY(Screen.Percent(0, 1).Y)
-            };
-            _legendGame = new Label(string.Empty, _legendGameBackground.Position.Shift(new Vector2f(_legendPadding, _legendPadding)), 14, SFML.Graphics.Color.Black, font);
+            var legendMappingPosition = _legendGame.Box
+                .PositionRelative(Joint.End, Joint.Start);
+            _legendIoMap = new Legend(string.Empty, 14, _legendPadding, chromeColor, Color.Black, 2, Bundle.Font, legendMappingPosition);
 
-            _legendMappingBackground = new RectangleShape
-            {
-                Size = legendBackgroundSize,
-                FillColor = chromeColor,
-                OutlineColor = Color.Black,
-                OutlineThickness = 2,
-                Position = _legendGameBackground.PositionRelative(Joint.End, Joint.Start)
-            };
-            _legendMapping = new Label(string.Empty, _legendMappingBackground.Position.Shift(new Vector2f(_legendPadding, _legendPadding)), 14, SFML.Graphics.Color.Black, font);
+            var legendHoveredEntityPosition = _menuBarBackground
+                .PositionRelative(Joint.End, Joint.Middle)
+                //.ShiftX(-_infoBoxBackgroundSize.X - _legendPadding * 2)
+                .ShiftY(-_legendSpacing);
 
-            _infoBoxBackgroundSize = Screen.Percent(30f, 15f);
-            _infoBoxBackground = new RectangleShape
-            {
-                Size = new Vector2f(0,0),
-                FillColor = chromeColor,
-                OutlineColor = Color.Black,
-                OutlineThickness = 2,
-                Position = menuBarBackground.PositionRelative(Joint.End, Joint.End)
-                    .ShiftX(-_infoBoxBackgroundSize.X - _legendPadding * 2)
-                    .ShiftY(_legendPadding)
-            };
-            _infoLabel = new Label(string.Empty, _infoBoxBackground.Position.Shift(new Vector2f(_legendPadding, _legendPadding)), 14, SFML.Graphics.Color.Black, font);
+            _legendHovered = new Legend(string.Empty, 14, _legendPadding, chromeColor, Color.Black, 2, Bundle.Font, legendHoveredEntityPosition);
 
-            //win/lose screens
-            Vector2f popupSize = Screen.Percent(15f, 10f);
-
-            _winPopupBox = new RectangleShape
-            {
-                Size = new Vector2f(0f, 0f),
-                FillColor = SFML.Graphics.Color.Green,
-                OutlineColor = Color.Black,
-                OutlineThickness = 2,
-                Position = _infoBoxBackground.PositionRelative(Joint.Start, Joint.End)
-                    .ShiftY(_legendPadding)
-            };
-
-            _losePopupBox = new RectangleShape
-            {
-                Size = new Vector2f(0f, 0f),
-                FillColor = SFML.Graphics.Color.Red,
-                OutlineColor = Color.Black,
-                OutlineThickness = 2,
-                Position = _infoBoxBackground.PositionRelative(Joint.Start, Joint.End)
-                    .ShiftY(_legendPadding)
-            };
-
-            _winPopup = new Label(string.Empty, _winPopupBox.Position.Shift(new Vector2f(_legendPadding, _legendPadding)), 14, SFML.Graphics.Color.Black, font);
-            _losePopup = new Label(string.Empty, _losePopupBox.Position.Shift(new Vector2f(_legendPadding, _legendPadding)), 14, SFML.Graphics.Color.Black, font);
-
+            _legendGameState = new Legend(_gameState.ToHumanString(), 18, 24, Color.Green, Color.Black, 2, Bundle.Font, default);
+            _legendGameState.Position = _menuBarBackground.PositionRelative(Joint.End, Joint.End)
+                .ShiftX(-_legendGameState.Box.GetGlobalBounds().Width - _legendSpacing)
+                .ShiftY(_legendSpacing);
+            
             //================= Game Entities ====================//
             _conveyor = new Conveyor(Screen.Percent(0, 60), Screen.Percent(100, 1), new Vector2f(1, 0));
 
             _marbles = preset.Marbles
-                .Select(mc => new Marble(Screen, new Vector2f(40, _conveyor.Position.Y), mc.Color.ToGameColor(), mc.Weight.ToGameWeight()))
+                .Select(mc => new Marble(new Vector2f(40, _conveyor.Position.Y), mc.Color.ToGameColor(), mc.Weight.ToGameWeight()))
                 .Reverse()
                 .ToArray();
+            
+            _marblesRemaining = new List<Marble>(_marbles);
 
             // Set marble initial positions based on screen dimensions
             float offset = 0;
@@ -264,9 +211,7 @@ namespace MarbleSorterGame.Screens
 
             // Adjust bucket positions to be at very bottom of screen
             foreach (var bucket in _buckets)
-            {
                 bucket.Position -= new Vector2f(0, bucket.Size.Y);
-            }
             
             Vector2f gateEntranceSize = Screen.Percent(0.5f, 0);
             gateEntranceSize.Y = Marble.MarbleSizeLarge;
@@ -375,7 +320,6 @@ namespace MarbleSorterGame.Screens
                 signalPressure2,
             };
 
-
             _entities = new GameEntity[]
             {
                 _buttonPause,
@@ -388,6 +332,10 @@ namespace MarbleSorterGame.Screens
                 _motionSensorConveyor,
                 _gateOpen,
                 _gateClosed,
+                _legendGame,
+                _legendIoMap,
+                _legendHovered,
+                _legendGameState,
                 bucketDropped,
                 trapdoorOpen1,
                 trapdoorOpen2,
@@ -406,14 +354,15 @@ namespace MarbleSorterGame.Screens
                 .Concat(new[] { _gateEntrance })
                 .ToArray();
 
-            _hoverable = new List<GameEntity>() { };
+            _hoverable = new List<GameEntity>();
+            _hoverable.AddRange(_buckets);
+            _hoverable.AddRange(_marbles);
             _hoverable.AddRange(_trapDoors);
             _hoverable.AddRange(_signalLights);
             _hoverable.AddRange(_sensors);
-            _hoverable.AddRange(_marbles);
             _hoverable.Add(_gateEntrance);
 
-            _mappable = new List<GameEntity>() { };
+            _mappable = new List<GameEntity>();
             _mappable.AddRange(_trapDoors);
             _mappable.Add(_gateEntrance);
             _mappable.Add(_conveyor);
@@ -431,22 +380,7 @@ namespace MarbleSorterGame.Screens
             foreach (GameEntity entity in _entities)
                 entity.Load(Bundle);
 
-            _drawables = new Drawable[]
-            {
-                //instructions,
-                //gameScreenTitle,
-                menuBarBackground,
-                _legendGameBackground,
-                _legendGame,
-                _legendMappingBackground,
-                _legendMapping,
-                _infoBoxBackground,
-                _infoLabel,
-                _winPopupBox,
-                _winPopup,
-                _losePopupBox,
-                _losePopup
-            };
+            _drawables = new Drawable[] { _menuBarBackground, };
         }
 
         // Mouse movement event handler for features involving hover-over
@@ -626,7 +560,9 @@ namespace MarbleSorterGame.Screens
                     {
                         // Set marble position offscreen and update bucket counters
                         marble.Position = new Vector2f(50, 50000);
+                        marble.SetState(MarbleState.Still);
                         bool success = bucket.InsertMarble(marble);
+                        _marblesRemaining.Remove(marble);
                     }
                 }
             }
@@ -646,27 +582,27 @@ namespace MarbleSorterGame.Screens
         private void UpdateLegend()
         {
             //IoMapConfiguration config = Bundle.IoMapConfiguration();
-            _legendGameData["Marbles Remaining Total"] = _marblesRemaining.ToString();
+            _legendGameData["Marbles Remaining Total"] = _marblesRemaining.Count.ToString();
             _legendGameData["Marbles Correctly Dropped"] = _buckets.Select(b => b.TotalCorrect).Sum().ToString();
             _legendGameData["Marbles Incorrectly Dropped"] = _buckets.Select(b => b.TotalIncorrect).Sum().ToString();
 
-            _IOMapping[IOKeys.I.TrapDoor1Open.ToString()] = _driver.TrapDoor1Open.ToString();
-            _IOMapping[IOKeys.I.TrapDoor2Open.ToString()] = _driver.TrapDoor2Open.ToString();
-            _IOMapping[IOKeys.I.TrapDoor3Open.ToString()] = _driver.TrapDoor3Open.ToString();
-            _IOMapping[IOKeys.I.TrapDoor1Closed.ToString()] = _driver.TrapDoor1Closed.ToString();
-            _IOMapping[IOKeys.I.TrapDoor2Closed.ToString()] = _driver.TrapDoor2Closed.ToString();
-            _IOMapping[IOKeys.I.TrapDoor3Closed.ToString()] = _driver.TrapDoor3Closed.ToString();
-            _IOMapping[IOKeys.I.BucketMotionSensor.ToString()] = _driver.BucketMotionSensor.ToString();
-            _IOMapping[IOKeys.I.WeightSensor.ToString()] = _driver.PressureSensor.ToString();
-            _IOMapping[IOKeys.I.ColorSensor.ToString()] = _driver.ColorSensor.ToString();
-            _IOMapping[IOKeys.I.ConveyorMotionSensor.ToString()] = _driver.ConveyorMotionSensor.ToString();
-            _IOMapping[IOKeys.I.GateClosed.ToString()] = _driver.GateClosed.ToString();
-            _IOMapping[IOKeys.I.GateOpen.ToString()] = _driver.GateOpen.ToString();
-            _IOMapping[IOKeys.Q.TrapDoor1.ToString()] = _driver.TrapDoor1.ToString();
-            _IOMapping[IOKeys.Q.TrapDoor2.ToString()] = _driver.TrapDoor2.ToString();
-            _IOMapping[IOKeys.Q.TrapDoor3.ToString()] = _driver.TrapDoor3.ToString();
-            _IOMapping[IOKeys.Q.Gate.ToString()] = _driver.Gate.ToString();
-            _IOMapping[IOKeys.Q.Conveyor.ToString()] = _driver.Conveyor.ToString();
+            _ioMapData[IOKeys.I.TrapDoor1Open] = _driver.TrapDoor1Open.ToString();
+            _ioMapData[IOKeys.I.TrapDoor2Open] = _driver.TrapDoor2Open.ToString();
+            _ioMapData[IOKeys.I.TrapDoor3Open] = _driver.TrapDoor3Open.ToString();
+            _ioMapData[IOKeys.I.TrapDoor1Closed] = _driver.TrapDoor1Closed.ToString();
+            _ioMapData[IOKeys.I.TrapDoor2Closed] = _driver.TrapDoor2Closed.ToString();
+            _ioMapData[IOKeys.I.TrapDoor3Closed] = _driver.TrapDoor3Closed.ToString();
+            _ioMapData[IOKeys.I.BucketMotionSensor] = _driver.BucketMotionSensor.ToString();
+            _ioMapData[IOKeys.I.WeightSensor] = _driver.PressureSensor.ToString();
+            _ioMapData[IOKeys.I.ColorSensor] = _driver.ColorSensor.ToString();
+            _ioMapData[IOKeys.I.ConveyorMotionSensor] = _driver.ConveyorMotionSensor.ToString();
+            _ioMapData[IOKeys.I.GateClosed] = _driver.GateClosed.ToString();
+            _ioMapData[IOKeys.I.GateOpen] = _driver.GateOpen.ToString();
+            _ioMapData[IOKeys.Q.TrapDoor1] = _driver.TrapDoor1.ToString();
+            _ioMapData[IOKeys.Q.TrapDoor2] = _driver.TrapDoor2.ToString();
+            _ioMapData[IOKeys.Q.TrapDoor3] = _driver.TrapDoor3.ToString();
+            _ioMapData[IOKeys.Q.Gate] = _driver.Gate.ToString();
+            _ioMapData[IOKeys.Q.Conveyor] = _driver.Conveyor.ToString();
 
             var legendGameBuilder = new System.Text.StringBuilder();
             var legendMappingBuilder = new System.Text.StringBuilder();
@@ -676,106 +612,87 @@ namespace MarbleSorterGame.Screens
 
             foreach (var entity in _mappable)
             {
-                IoMapConfiguration entityConfig = Bundle.IoMapConfiguration.Find(e => e.EntityName == entity.Name);
+                var entityConf = Bundle.IoMapConfiguration.Find(e => e.EntityName == entity.Name);
+                if (entityConf != null)
+                    legendMappingBuilder.AppendLine($"{entityConf.ToAddressString()}-{entityConf.Description,-30}: {_ioMapData[entity.Name]}");
+            }
 
-                legendMappingBuilder.AppendLine(string.Format("{0}-{1,-30}: {2}",
-                    "%" + entityConfig.MemoryArea + entityConfig.Byte.ToString() + "." + entityConfig.Bit.ToString(),
-                    entityConfig.Description,
-                    _IOMapping[entity.Name] 
-                    ));
+            _legendGame.DisplayedText = legendGameBuilder.ToString();
+            _legendIoMap.DisplayedText = legendMappingBuilder.ToString();
 
+            _legendIoMap.Position = _legendGame.Box
+                .PositionRelative(Joint.End, Joint.Start)
+                .ShiftX(_legendSpacing);
+            
+            _legendHovered.Hidden = true;
+            if (_hoveredEntity != null)
+            {
+                var hoveredItemStringBuilder = new System.Text.StringBuilder();
+                var config = Bundle.IoMapConfiguration.Find(e => e.EntityName == _hoveredEntity.Name);
+                _hoveredEntityData["Currently Hovered Item"] = config?.Description ?? _hoveredEntity.Name;
+                _hoveredEntityData["Item Address"] = config?.ToAddressString();
+                
+                foreach (var (key,value) in _hoveredEntityData) 
+                    if (!string.IsNullOrEmpty(value))
+                        hoveredItemStringBuilder.AppendLine(string.Format("{0,-23}: {1}", key, value));
+                
+                _legendHovered.DisplayedText = hoveredItemStringBuilder.ToString();
+                _legendHovered.Hidden = false;
+                _legendHovered.Position = _legendIoMap.Box
+                    .PositionRelative(Joint.End, Joint.Start)
+                    .ShiftX(_legendSpacing);
             }
             
-            _legendGame.Text = legendGameBuilder.ToString();
-            _legendMapping.Text = legendMappingBuilder.ToString();
-
-            // Automatically adjust background height and width according to height of the text label
-            var legendBounds = _legendGame.LabelText.GetGlobalBounds();
-            _legendGameBackground.Size = new Vector2f(legendBounds.Width + _legendPadding*4, legendBounds.Height + _legendPadding*2);
-            legendBounds = _legendMapping.LabelText.GetGlobalBounds();
-            _legendMappingBackground.Size = new Vector2f(legendBounds.Width + _legendPadding*4, legendBounds.Height + _legendPadding*2);
-            _legendMappingBackground.Position = _legendGameBackground.PositionRelative(Joint.End, Joint.Start).ShiftX(_legendPadding);
-
-            _legendMapping.LabelPosition = _legendMappingBackground.Position.Shift(new Vector2f(_legendPadding, _legendPadding));
-
-        }
-
-        // Update info box data for hover-over entities
-        private void UpdateInfoBox()
-        {
-            if (_hoveredEntity == null)
-            {
-                _infoLabel.Text = string.Empty;
-                _infoBoxBackground.Size = default;
-                return;
-            }
-
-            string hoveredEntityAddress = null;
-            string hoveredEntityDescription = null;
-
-            if (_hoveredEntity.GetType() == _marbles[0].GetType())
-            {
-                hoveredEntityDescription = _hoveredEntity.ToString();
-            } else
-            {
-                IoMapConfiguration hoveredEntityConfig = Bundle.IoMapConfiguration.Find(entity => entity.EntityName == _hoveredEntity.Name);
-                if (hoveredEntityConfig != null)
-                {
-                    hoveredEntityAddress = "%" + hoveredEntityConfig.MemoryArea + hoveredEntityConfig.Byte.ToString() + "." + hoveredEntityConfig.Bit.ToString();
-                    hoveredEntityDescription = hoveredEntityConfig.Description;
-                }
-            }
-
-            _infoData["Currently Hovered Item"] = _hoveredEntity == null ? "N/A" : hoveredEntityDescription;
-            _infoData["Item Address"] = _hoveredEntity == null ? "N/A" : hoveredEntityAddress;
-
-            var legendBuilder = new System.Text.StringBuilder();
-            foreach (var stat in _infoData)
-                legendBuilder.AppendLine(string.Format("{0,-23}: {1}", stat.Key, stat.Value));
-            
-            _infoLabel.Text = legendBuilder.ToString();
-            // Automatically adjust background height and width according to height of the text label
-            var bounds = _infoLabel.LabelText.GetGlobalBounds();
-
-            //show info box background
-            _infoBoxBackground.Size = _infoBoxBackgroundSize;
+            _legendGameState.DisplayedText = _gameState.ToHumanString();
+            _legendGameState.BackgroundColor = _gameState.ToIndicatorColor();
+            _legendGameState.Position = _menuBarBackground.PositionRelative(Joint.End, Joint.End)
+                .ShiftX(-_legendGameState.Box.GetGlobalBounds().Width - _legendSpacing)
+                .ShiftY(_legendSpacing);
         }
 
         // Update game state from key events such as bucket handling and win state
         public void UpdateGameState()
         {
-            _marblesRemaining = _marblesTotal - _buckets.Select(b => b.TotalMarbles).Sum();
-            int marblesCorrectDrop = _buckets.Select(b => b.TotalCorrect).Sum();
-            int marblesIncorrectDrop = _buckets.Select(b => b.TotalIncorrect).Sum();
-
-            //check if marble that passed through all trapdoors was supposed to be in a bucket
-            foreach (var marble in _marbles)
+            // Once game state is win or lose, this method cannot change it
+            if (_gameState == GameState.Win || _gameState == GameState.Lose)
+                return;
+            
+            // If there are no marbles remaining, and there are no buckets with incorrect marbles, set win state
+            if (_marblesRemaining.Count == 0 && _buckets.Select(b => b.TotalIncorrect).Sum() == 0)
             {
-                if (marble.Position.X - marble.Radius > Window.Size.X)
-                {
-                    if (_buckets.Any(b => b.ValidateMarble(marble)))
-                        marblesCorrectDrop++;
-                    else
-                        marblesIncorrectDrop++;
-
-                    _marblesRemaining--;
-                }
+                _gameState = GameState.Win;
+                return;
             }
 
-            //check game win state
-            if (_marblesRemaining == 0 && marblesIncorrectDrop == 0)
-                _gameState = GameState.Win;
-            else if (marblesIncorrectDrop > 0)
+            // if any buckets have gained an incorrect marble, set state to lose
+            if (_buckets.Select(b => b.TotalIncorrect).Sum() > 0)
+            {
                 _gameState = GameState.Lose;
+                return;
+            }
+
+            // Maybe find a marble that has gone past screen edge
+            Marble? maybeOverEdgeMarble = _marblesRemaining.Find(m => m.Position.X - m.Radius > Window.Size.X);
+
+            if (maybeOverEdgeMarble == null)
+                return;
+
+            // Remove it from marbles remaining list
+            _marblesRemaining.Remove(maybeOverEdgeMarble);
+
+            // If edge marble marble could have successfully entered a bucket, set lose state
+            if (_buckets.Any(b => b.ValidateMarble(maybeOverEdgeMarble)))
+            {
+                _gameState = GameState.Lose;
+            }
         }
 
         // Update all game entity positions, game state and driver input/output
         public override void Update()
         {
             UpdateLegend();
-            UpdateInfoBox();
 
-            if (_gameState == GameState.Progress)
+            if (_gameState != GameState.Pause)
             {
                 UpdateDriver();
                 UpdateSignals();
@@ -783,28 +700,8 @@ namespace MarbleSorterGame.Screens
                 UpdateDoors();
                 UpdateGameState(); // Win, lose, or pause
             }
-
-            UpdateWinState();
         }
 
-        //show win/lose popup box if win/lose
-        public void UpdateWinState()
-        {
-            Vector2f popupSize = new Vector2f(100f, 30f);
-
-            if (_gameState == GameState.Win)
-            {
-                _winPopupBox.Size = popupSize;
-                _winPopup.Text = "YOU WIN";
-            } 
-            else if (_gameState == GameState.Lose)
-            {
-                _losePopupBox.Size = popupSize;
-                _losePopup.Text = "YOU LOSE";
-            }
-
-        }
-        
         // Redraw screen in preparation for next update loop
         public override void Draw(RenderWindow window)
         {
@@ -822,9 +719,6 @@ namespace MarbleSorterGame.Screens
                 _gameState = GameState.Progress;
             else if (_gameState == GameState.Progress)
                 _gameState = GameState.Pause;
-            
-            //if (_driver is S7IODriver s7driver)
-            //   s7driver.SetRunState(true);
         }
 
         // Event handler for reset button click

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/MarbleSorterScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/MarbleSorterScreen.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Text;
 using MarbleSorterGame.Enums;
 using MarbleSorterGame.GameEntities;
 using MarbleSorterGame.Utilities;
@@ -157,8 +158,8 @@ namespace MarbleSorterGame.Screens
                 //.ShiftX(-_infoBoxBackgroundSize.X - _legendPadding * 2)
                 .ShiftY(-_legendSpacing);
 
-            _legendHovered = new Legend(string.Empty, 14, _legendPadding, chromeColor, Color.Black, 2, Bundle.Font, legendHoveredEntityPosition);
-
+            _legendHovered = new Legend(string.Empty, 18, _legendPadding, chromeColor, Color.Black, 2, Bundle.Font, legendHoveredEntityPosition);
+            
             _legendGameState = new Legend(_gameState.ToHumanString(), 18, 24, Color.Green, Color.Black, 2, Bundle.Font, default);
             _legendGameState.Position = _menuBarBackground.PositionRelative(Joint.End, Joint.End)
                 .ShiftX(-_legendGameState.Box.GetGlobalBounds().Width - _legendSpacing)
@@ -213,8 +214,8 @@ namespace MarbleSorterGame.Screens
             foreach (var bucket in _buckets)
                 bucket.Position -= new Vector2f(0, bucket.Size.Y);
             
-            Vector2f gateEntranceSize = Screen.Percent(0.5f, 0);
-            gateEntranceSize.Y = Marble.MarbleSizeLarge;
+            Vector2f gateEntranceSize = Screen.Percent(0.75f, 0);
+            gateEntranceSize.Y = Marble.MarbleSizeLarge * 1.25f;
             // screen.Percent(13, 52)
             _gateEntrance = new Gate(
                 _conveyor.Box
@@ -604,8 +605,8 @@ namespace MarbleSorterGame.Screens
             _ioMapData[IOKeys.Q.Gate] = _driver.Gate.ToString();
             _ioMapData[IOKeys.Q.Conveyor] = _driver.Conveyor.ToString();
 
-            var legendGameBuilder = new System.Text.StringBuilder();
-            var legendMappingBuilder = new System.Text.StringBuilder();
+            var legendGameBuilder = new StringBuilder();
+            var legendMappingBuilder = new StringBuilder();
 
             foreach (var stat in _legendGameData)
                 legendGameBuilder.AppendLine(string.Format("{0,-40}: {1}", stat.Key, stat.Value));
@@ -627,14 +628,14 @@ namespace MarbleSorterGame.Screens
             _legendHovered.Hidden = true;
             if (_hoveredEntity != null)
             {
-                var hoveredItemStringBuilder = new System.Text.StringBuilder();
+                var hoveredItemStringBuilder = new StringBuilder();
                 var config = Bundle.IoMapConfiguration.Find(e => e.EntityName == _hoveredEntity.Name);
-                _hoveredEntityData["Currently Hovered Item"] = config?.Description ?? _hoveredEntity.Name;
-                _hoveredEntityData["Item Address"] = config?.ToAddressString();
+                _hoveredEntityData["Description"] = config?.Description ?? _hoveredEntity.Name;
+                _hoveredEntityData["IO Address"] = config?.ToAddressString();
                 
                 foreach (var (key,value) in _hoveredEntityData) 
                     if (!string.IsNullOrEmpty(value))
-                        hoveredItemStringBuilder.AppendLine(string.Format("{0,-23}: {1}", key, value));
+                        hoveredItemStringBuilder.AppendLine($"{key}: {value}");
                 
                 _legendHovered.DisplayedText = hoveredItemStringBuilder.ToString();
                 _legendHovered.Hidden = false;


### PR DESCRIPTION
- Introduce Legend class to avoid copy+paste between legends
- Display bucket requirements when hovered
- Display marble attributes when hovered
- Re-Implement entity hovered "InfoBox" as just another legend
- Re-implement game win/lose detection based on a list of "marbles remaining" on board
- Add a colorful legend/indicator to show current game state (paused, win, lost, etc)
- Prevent game from starting with resolution < 1270x720
- Catch any errors thrown in GameScreen constructors
- Fix incorrect signal indicators going off for TrapDoor (invert Closed/Open angle condition)

Closes #95
Closes #112 
Closes #111 
Closes #109 
Closes #110 
Closes #108 
