### PR TITLE
Attempt to power-on and run simulation when starting new marble sorter game

### DIFF
--- a/src/MarbleSorterGame/MarbleSorterGame/Drivers/IIODriver.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Drivers/IIODriver.cs
@@ -57,5 +57,8 @@ namespace MarbleSorterGame
 
         // Updates driver to communicate to/from the game
         public void Update();
+
+        // Enable or disable the driver (if supported)
+        public void SetActive(bool active);
     }
 }

--- a/src/MarbleSorterGame/MarbleSorterGame/Drivers/KeyboardIODriver.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Drivers/KeyboardIODriver.cs
@@ -1,4 +1,3 @@
-using System;
 using SFML.Window;
 
 namespace MarbleSorterGame
@@ -25,14 +24,26 @@ namespace MarbleSorterGame
         public byte PressureSensor { get; set; }
         public byte ColorSensor { get; set; }
 
+        // Whether or not to enable inputs from the driver
+        private bool _active = false;
+
         // This implementation does not update programatically, it uses keyboard input. See: UpdateByKey()
         public void Update()
         {
         }
 
+        public void SetActive(bool active)
+        {
+            _active = active;
+        }
+
         // Associates and Updates keyboard inputs to game inputs
         public void UpdateByKey(KeyEventArgs key)
         {
+            // Do not update state if driver state is inactive
+            if (!_active)
+                return;
+
             // Outputs: TrapDoor1, TrapDoor2, TrapDoor3, Gate, Conveyer
             if (key.Code == Keyboard.Key.Num1)
                 Gate = !Gate;

--- a/src/MarbleSorterGame/MarbleSorterGame/Drivers/S7IODriver.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Drivers/S7IODriver.cs
@@ -148,6 +148,7 @@ namespace MarbleSorterGame
 
         private ulong _updateCount;
         private readonly uint _updateInterval;
+        private bool _active = false;
 
         // Defines the addresses for the S7IO PLC Driver
         public S7IODriver(SimulationDriverOptions options, IList<IoMapConfiguration> iomaps)
@@ -168,17 +169,27 @@ namespace MarbleSorterGame
         }
         
         // Sets run state of the client
-        public void SetRunState(bool run)
+        public void SetActive(bool active)
         {
-            if (run)
+            _active = active;
+            if (active)
+            {
+                _client.PowerOn();
                 _client.Run();
+            }
             else
+            {
                 _client.Stop();
+                _client.PowerOff();
+            }
         }
         
         // Updates driver values by writing/reading from the game state
         public void Update()
         {
+            if (!_active)
+                return;
+
             if (_updateCount % _updateInterval == 0)
             {
                 // Write simulation outputs

--- a/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.csproj
+++ b/src/MarbleSorterGame/MarbleSorterGame/MarbleSorterGame.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="SFML.Net" Version="2.5.0" />
     </ItemGroup>
 

--- a/src/MarbleSorterGame/MarbleSorterGame/Program.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Program.cs
@@ -30,6 +30,9 @@ namespace MarbleSorterGame
             
             MarbleSorterGame msg = new MarbleSorterGame(bundle, driver, exception);
             msg.Run();
+            
+            // Stop and power-off the simulation if it is running
+            driver?.SetActive(false);
         }
     }
 }

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/MainMenuScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/MainMenuScreen.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using MarbleSorterGame.Enums;
 using MarbleSorterGame.GameEntities;
 using MarbleSorterGame.Utilities;
-using Newtonsoft.Json;
 using SFML.Graphics;
 using SFML.System;
 using SFML.Window;

--- a/src/MarbleSorterGame/MarbleSorterGame/Screens/MarbleSorterScreen.cs
+++ b/src/MarbleSorterGame/MarbleSorterGame/Screens/MarbleSorterScreen.cs
@@ -90,6 +90,9 @@ namespace MarbleSorterGame.Screens
             _hoveredEntityData = new Dictionary<string, string>();
             
             _gameState = GameState.Progress;
+            
+            // Enable IO for the driver
+            _driver.SetActive(true);
 
             //================= Event Handlers ====================//
             Window.MouseButtonPressed += GameMouseClickEventHandler;

--- a/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationClient.cs
+++ b/src/S7PLCSIM-Library/S7PLCSIM-Library/SimulationClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using Siemens.Simatic.Simulation.Runtime;
 
 namespace S7PLCSIM_Library
@@ -76,6 +77,13 @@ namespace S7PLCSIM_Library
                 if (error != ERuntimeErrorCode.OK)
                 {
                     throw new S7PlcSimLibraryException($"Error powering on the simulation, error code: {Enum.GetName(typeof(ERuntimeErrorCode), error)}");
+                }
+                
+                // Do not return until we are through the "booting" phase
+                // This prevents Run() from not working when we call PowerOn() followed by Run()
+                while (OperatingState == EOperatingState.Booting)
+                {
+                    Thread.Sleep(100);
                 }
             }
         }


### PR DESCRIPTION
Closes #124

- Poweron simulation when marble sorter game screen starts
- Poweroff the simulation when the SFML window closes
- Remove unused imports, unused dependency on Newtonsoft.Json
- Library: Sleep through booting state in PowerOn()
- Add SetActive() to IIODriver
